### PR TITLE
feat: add a burn_nonce method to multisig

### DIFF
--- a/contracts/IMultisigControl.sol
+++ b/contracts/IMultisigControl.sol
@@ -40,6 +40,14 @@ abstract contract IMultisigControl {
     /// @dev MUST emit 'SignerRemoved' event
     function remove_signer(address old_signer, uint nonce, bytes calldata signatures) public virtual;
 
+    /// @notice Burn an nonce before it gets used by a user. Useful in case the validators needs to prevents a malicious user to do un-permitted action.
+    /// @param nonce Vega-assigned single-use number that provides replay attack protection
+    /// @param signatures Vega-supplied signature bundle of a validator-signed order
+    /// @notice See MultisigControl for more about signatures
+    /// @dev Emits 'NonceBurnt' event
+    function burn_nonce(uint256 nonce, bytes calldata signatures) public virtual;
+
+
     /// @notice Verifies a signature bundle and returns true only if the threshold of valid signers is met,
     /// @notice this is a function that any function controlled by Vega MUST call to be securely controlled by the Vega network
     /// @notice message to hash to sign follows this pattern:

--- a/contracts/IMultisigControl.sol
+++ b/contracts/IMultisigControl.sol
@@ -11,6 +11,7 @@ abstract contract IMultisigControl {
     event SignerAdded(address new_signer, uint256 nonce);
     event SignerRemoved(address old_signer, uint256 nonce);
     event ThresholdSet(uint16 new_threshold, uint256 nonce);
+    event NonceBurnt(uint256 nonce);
 
     /**************************FUNCTIONS*********************/
     /// @notice Sets threshold of signatures that must be met before function is executed.

--- a/contracts/MultisigControl.sol
+++ b/contracts/MultisigControl.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: MIT
+\41;2500;0c//SPDX-License-Identifier: MIT
 pragma solidity 0.8.8;
 
 import "./IMultisigControl.sol";
@@ -17,7 +17,7 @@ contract MultisigControl is IMultisigControl {
 
     uint16 threshold;
     uint8 signer_count;
-    mapping(address => bool) signers;
+    mapping(address => bool) public signers;
     mapping(uint => bool) used_nonces;
     mapping(bytes32 => mapping(address => bool)) has_signed;
 

--- a/contracts/MultisigControl.sol
+++ b/contracts/MultisigControl.sol
@@ -68,6 +68,17 @@ contract MultisigControl is IMultisigControl {
         emit SignerRemoved(old_signer, nonce);
     }
 
+    /// @notice Burn an nonce before it gets used by a user. Useful in case the validators needs to prevents a malicious user to do un-permitted action.
+    /// @param nonce Vega-assigned single-use number that provides replay attack protection
+    /// @param signatures Vega-supplied signature bundle of a validator-signed order
+    /// @notice See MultisigControl for more about signatures
+    /// @dev Emits 'NonceBurnt' event
+    function burn_nonce(uint256 nonce, bytes calldata signatures) public override {
+        bytes memory message = abi.encode(nonce, "burn_nonce");
+        require(verify_signatures(signatures, message, nonce), "bad signatures");
+        emit NonceBurnt(nonce);
+    }
+
     /// @notice Verifies a signature bundle and returns true only if the threshold of valid signers is met,
     /// @notice this is a function that any function controlled by Vega MUST call to be securely controlled by the Vega network
     /// @notice message to hash to sign follows this pattern:


### PR DESCRIPTION
Add a burn nonce method. this would be useful in the case we want to stop a deposit to happen.

E.g:
- Malicious user try to withdraw 1 GAZILLIONS VEGA (he's exploiting a bug...)
- There's a delay of 1 day before they can do it.
- Validators notice the bug
- They emit a burn_nonce transaction
- Someone submit the transaction before the 1 day delay.
- The nonce is burnt
- The malicious user try to withdraw the 1 GAZILLIONS VEGA -> this doesn't work
- Malicious user 0 - VEGA 1 