### PR TITLE
chore: run prettier on all solidity code

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,15 @@
+{
+  "overrides": [
+    {
+      "files": "*.sol",
+      "options": {
+        "printWidth": 120,
+        "tabWidth": 4,
+        "useTabs": false,
+        "singleQuote": false,
+        "bracketSpacing": false,
+        "explicitTypes": "always"
+      }
+    }
+  ]
+}

--- a/contracts/ETH_Asset_Pool.sol
+++ b/contracts/ETH_Asset_Pool.sol
@@ -40,17 +40,9 @@ contract ETH_Asset_Pool {
             size := extcodesize(new_address)
         }
         require(size > 0, "new address must be contract");
-        bytes memory message = abi.encode(
-            new_address,
-            nonce,
-            "set_multisig_control"
-        );
+        bytes memory message = abi.encode(new_address, nonce, "set_multisig_control");
         require(
-            IMultisigControl(multisig_control_address).verify_signatures(
-                signatures,
-                message,
-                nonce
-            ),
+            IMultisigControl(multisig_control_address).verify_signatures(signatures, message, nonce),
             "bad signatures"
         );
         multisig_control_address = new_address;
@@ -67,17 +59,9 @@ contract ETH_Asset_Pool {
         uint256 nonce,
         bytes memory signatures
     ) public {
-        bytes memory message = abi.encode(
-            new_address,
-            nonce,
-            "set_bridge_address"
-        );
+        bytes memory message = abi.encode(new_address, nonce, "set_bridge_address");
         require(
-            IMultisigControl(multisig_control_address).verify_signatures(
-                signatures,
-                message,
-                nonce
-            ),
+            IMultisigControl(multisig_control_address).verify_signatures(signatures, message, nonce),
             "bad signatures"
         );
         ETH_bridge_address = new_address;
@@ -89,10 +73,7 @@ contract ETH_Asset_Pool {
     /// @param amount Amount of ETH to withdraw
     /// @dev amount is in wei, 1 wei == 0.000000000000000001 ETH
     function withdraw(address payable target, uint256 amount) public {
-        require(
-            msg.sender == ETH_bridge_address,
-            "msg.sender not authorized bridge"
-        );
+        require(msg.sender == ETH_bridge_address, "msg.sender not authorized bridge");
         /// @dev reentry is protected by the non-reusable nonce in the signature check in the ETH_Bridge_Logic
         (bool success, ) = target.call{value: amount}("");
         require(success, "eth transfer failed");

--- a/contracts/ETH_Bridge_Logic.sol
+++ b/contracts/ETH_Bridge_Logic.sol
@@ -10,7 +10,6 @@ import "./ETH_Asset_Pool.sol";
 /// @notice This contract is used by Vega network users to deposit and withdraw ETH to/from Vega.
 // @notice All funds deposited/withdrawn are to/from the assigned ETH_Asset_Pool
 contract ETH_Bridge_Logic is IETH_Bridge_Logic {
-
     address payable ETH_asset_pool_address;
 
     // minimum deposit amt
@@ -24,18 +23,36 @@ contract ETH_Bridge_Logic is IETH_Bridge_Logic {
     constructor(address payable ETH_asset_pool) {
         ETH_asset_pool_address = ETH_asset_pool;
     }
-    function multisig_control_address() internal view returns(address) {
-        return ETH_Asset_Pool(ETH_asset_pool_address).multisig_control_address();
+
+    function multisig_control_address() internal view returns (address) {
+        return
+            ETH_Asset_Pool(ETH_asset_pool_address).multisig_control_address();
     }
+
     /// @notice This function sets the minimum allowable deposit for ETH
     /// @param minimum_amount Minimum deposit amount
     /// @param nonce Vega-assigned single-use number that provides replay attack protection
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev Emits ETH_Deposit_Minimum_Set if successful
-    function set_deposit_minimum(uint256 minimum_amount, uint256 nonce, bytes memory signatures) public override{
-        bytes memory message = abi.encode(minimum_amount, nonce, 'set_deposit_minimum');
-        require(IMultisigControl(multisig_control_address()).verify_signatures(signatures, message, nonce), "bad signatures");
+    function set_deposit_minimum(
+        uint256 minimum_amount,
+        uint256 nonce,
+        bytes memory signatures
+    ) public override {
+        bytes memory message = abi.encode(
+            minimum_amount,
+            nonce,
+            "set_deposit_minimum"
+        );
+        require(
+            IMultisigControl(multisig_control_address()).verify_signatures(
+                signatures,
+                message,
+                nonce
+            ),
+            "bad signatures"
+        );
         minimum_deposit = minimum_amount;
         emit ETH_Deposit_Minimum_Set(minimum_amount, nonce);
     }
@@ -46,9 +63,24 @@ contract ETH_Bridge_Logic is IETH_Bridge_Logic {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev Emits ETH_Deposit_Maximum_Set if successful
-    function set_deposit_maximum(uint256 maximum_amount, uint256 nonce, bytes memory signatures) public override {
-        bytes memory message = abi.encode(maximum_amount, nonce, 'set_deposit_maximum');
-        require(IMultisigControl(multisig_control_address()).verify_signatures(signatures, message, nonce), "bad signatures");
+    function set_deposit_maximum(
+        uint256 maximum_amount,
+        uint256 nonce,
+        bytes memory signatures
+    ) public override {
+        bytes memory message = abi.encode(
+            maximum_amount,
+            nonce,
+            "set_deposit_maximum"
+        );
+        require(
+            IMultisigControl(multisig_control_address()).verify_signatures(
+                signatures,
+                message,
+                nonce
+            ),
+            "bad signatures"
+        );
         maximum_deposit = maximum_amount;
         emit ETH_Deposit_Maximum_Set(maximum_amount, nonce);
     }
@@ -61,10 +93,29 @@ contract ETH_Bridge_Logic is IETH_Bridge_Logic {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev Emits ETH_Withdrawn if successful
-    function withdraw_asset(uint256 amount, uint256 expiry, address payable target, uint256 nonce, bytes memory signatures) public  override {
+    function withdraw_asset(
+        uint256 amount,
+        uint256 expiry,
+        address payable target,
+        uint256 nonce,
+        bytes memory signatures
+    ) public override {
         require(expiry > block.timestamp, "withdrawal has expired");
-        bytes memory message = abi.encode(amount, expiry, target,  nonce, 'withdraw_asset');
-        require(IMultisigControl(multisig_control_address()).verify_signatures(signatures, message, nonce), "bad signatures");
+        bytes memory message = abi.encode(
+            amount,
+            expiry,
+            target,
+            nonce,
+            "withdraw_asset"
+        );
+        require(
+            IMultisigControl(multisig_control_address()).verify_signatures(
+                signatures,
+                message,
+                nonce
+            ),
+            "bad signatures"
+        );
         ETH_Asset_Pool(ETH_asset_pool_address).withdraw(target, amount);
         emit ETH_Withdrawn(target, amount, nonce);
     }
@@ -73,7 +124,10 @@ contract ETH_Bridge_Logic is IETH_Bridge_Logic {
     /// @param vega_public_key Target vega public key to be credited with this deposit
     /// @dev Emits ETH_Deposited if successful
     function deposit_asset(bytes32 vega_public_key) public payable override {
-        require(maximum_deposit == 0 || msg.value <= maximum_deposit, "deposit above maximum");
+        require(
+            maximum_deposit == 0 || msg.value <= maximum_deposit,
+            "deposit above maximum"
+        );
         require(msg.value >= minimum_deposit, "deposit below minimum");
         ETH_asset_pool_address.transfer(msg.value);
         emit ETH_Deposited(msg.sender, msg.value, vega_public_key);
@@ -82,26 +136,30 @@ contract ETH_Bridge_Logic is IETH_Bridge_Logic {
     /***************************VIEWS*****************************/
     /// @notice This view returns minimum valid deposit
     /// @return Minimum valid deposit of ETH
-    function get_deposit_minimum() public override view returns(uint256){
+    function get_deposit_minimum() public view override returns (uint256) {
         return minimum_deposit;
     }
 
     /// @notice This view returns maximum valid deposit
     /// @return Maximum valid deposit of ETH
-    function get_deposit_maximum() public override view returns(uint256){
+    function get_deposit_maximum() public view override returns (uint256) {
         return maximum_deposit;
     }
 
     /// @return current multisig_control_address
-    function get_multisig_control_address() public override view returns(address) {
+    function get_multisig_control_address()
+        public
+        view
+        override
+        returns (address)
+    {
         return multisig_control_address();
     }
 
     /// @return The assigned Vega Asset Id
-    function get_vega_asset_id() public override view returns(bytes32){
+    function get_vega_asset_id() public view override returns (bytes32) {
         return vega_asset_id;
     }
-
 }
 
 /**

--- a/contracts/ETH_Bridge_Logic.sol
+++ b/contracts/ETH_Bridge_Logic.sol
@@ -25,8 +25,7 @@ contract ETH_Bridge_Logic is IETH_Bridge_Logic {
     }
 
     function multisig_control_address() internal view returns (address) {
-        return
-            ETH_Asset_Pool(ETH_asset_pool_address).multisig_control_address();
+        return ETH_Asset_Pool(ETH_asset_pool_address).multisig_control_address();
     }
 
     /// @notice This function sets the minimum allowable deposit for ETH
@@ -40,17 +39,9 @@ contract ETH_Bridge_Logic is IETH_Bridge_Logic {
         uint256 nonce,
         bytes memory signatures
     ) public override {
-        bytes memory message = abi.encode(
-            minimum_amount,
-            nonce,
-            "set_deposit_minimum"
-        );
+        bytes memory message = abi.encode(minimum_amount, nonce, "set_deposit_minimum");
         require(
-            IMultisigControl(multisig_control_address()).verify_signatures(
-                signatures,
-                message,
-                nonce
-            ),
+            IMultisigControl(multisig_control_address()).verify_signatures(signatures, message, nonce),
             "bad signatures"
         );
         minimum_deposit = minimum_amount;
@@ -68,17 +59,9 @@ contract ETH_Bridge_Logic is IETH_Bridge_Logic {
         uint256 nonce,
         bytes memory signatures
     ) public override {
-        bytes memory message = abi.encode(
-            maximum_amount,
-            nonce,
-            "set_deposit_maximum"
-        );
+        bytes memory message = abi.encode(maximum_amount, nonce, "set_deposit_maximum");
         require(
-            IMultisigControl(multisig_control_address()).verify_signatures(
-                signatures,
-                message,
-                nonce
-            ),
+            IMultisigControl(multisig_control_address()).verify_signatures(signatures, message, nonce),
             "bad signatures"
         );
         maximum_deposit = maximum_amount;
@@ -101,19 +84,9 @@ contract ETH_Bridge_Logic is IETH_Bridge_Logic {
         bytes memory signatures
     ) public override {
         require(expiry > block.timestamp, "withdrawal has expired");
-        bytes memory message = abi.encode(
-            amount,
-            expiry,
-            target,
-            nonce,
-            "withdraw_asset"
-        );
+        bytes memory message = abi.encode(amount, expiry, target, nonce, "withdraw_asset");
         require(
-            IMultisigControl(multisig_control_address()).verify_signatures(
-                signatures,
-                message,
-                nonce
-            ),
+            IMultisigControl(multisig_control_address()).verify_signatures(signatures, message, nonce),
             "bad signatures"
         );
         ETH_Asset_Pool(ETH_asset_pool_address).withdraw(target, amount);
@@ -124,10 +97,7 @@ contract ETH_Bridge_Logic is IETH_Bridge_Logic {
     /// @param vega_public_key Target vega public key to be credited with this deposit
     /// @dev Emits ETH_Deposited if successful
     function deposit_asset(bytes32 vega_public_key) public payable override {
-        require(
-            maximum_deposit == 0 || msg.value <= maximum_deposit,
-            "deposit above maximum"
-        );
+        require(maximum_deposit == 0 || msg.value <= maximum_deposit, "deposit above maximum");
         require(msg.value >= minimum_deposit, "deposit below minimum");
         ETH_asset_pool_address.transfer(msg.value);
         emit ETH_Deposited(msg.sender, msg.value, vega_public_key);
@@ -147,12 +117,7 @@ contract ETH_Bridge_Logic is IETH_Bridge_Logic {
     }
 
     /// @return current multisig_control_address
-    function get_multisig_control_address()
-        public
-        view
-        override
-        returns (address)
-    {
+    function get_multisig_control_address() public view override returns (address) {
         return multisig_control_address();
     }
 

--- a/contracts/IERC20.sol
+++ b/contracts/IERC20.sol
@@ -23,7 +23,9 @@ interface IERC20 {
      *
      * Emits a {Transfer} event.
      */
-    function transfer(address recipient, uint256 amount) external returns (bool);
+    function transfer(address recipient, uint256 amount)
+        external
+        returns (bool);
 
     /**
      * @dev Returns the remaining number of tokens that `spender` will be
@@ -32,7 +34,10 @@ interface IERC20 {
      *
      * This value changes when {approve} or {transferFrom} are called.
      */
-    function allowance(address owner, address spender) external view returns (uint256);
+    function allowance(address owner, address spender)
+        external
+        view
+        returns (uint256);
 
     /**
      * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
@@ -59,7 +64,11 @@ interface IERC20 {
      *
      * Emits a {Transfer} event.
      */
-    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
 
     /**
      * @dev Emitted when `value` tokens are moved from one account (`from`) to
@@ -73,5 +82,9 @@ interface IERC20 {
      * @dev Emitted when the allowance of a `spender` for an `owner` is set by
      * a call to {approve}. `value` is the new allowance.
      */
-    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
 }

--- a/contracts/IERC20.sol
+++ b/contracts/IERC20.sol
@@ -23,9 +23,7 @@ interface IERC20 {
      *
      * Emits a {Transfer} event.
      */
-    function transfer(address recipient, uint256 amount)
-        external
-        returns (bool);
+    function transfer(address recipient, uint256 amount) external returns (bool);
 
     /**
      * @dev Returns the remaining number of tokens that `spender` will be
@@ -34,10 +32,7 @@ interface IERC20 {
      *
      * This value changes when {approve} or {transferFrom} are called.
      */
-    function allowance(address owner, address spender)
-        external
-        view
-        returns (uint256);
+    function allowance(address owner, address spender) external view returns (uint256);
 
     /**
      * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
@@ -82,9 +77,5 @@ interface IERC20 {
      * @dev Emitted when the allowance of a `spender` for an `owner` is set by
      * a call to {approve}. `value` is the new allowance.
      */
-    event Approval(
-        address indexed owner,
-        address indexed spender,
-        uint256 value
-    );
+    event Approval(address indexed owner, address indexed spender, uint256 value);
 }

--- a/contracts/IERC20_Bridge_Logic_Restricted.sol
+++ b/contracts/IERC20_Bridge_Logic_Restricted.sol
@@ -7,29 +7,16 @@ pragma solidity 0.8.8;
 // @notice All funds deposited/withdrawn are to/from the ERC20_Asset_Pool
 abstract contract IERC20_Bridge_Logic_Restricted {
     /***************************EVENTS****************************/
-    event Asset_Withdrawn(
-        address indexed user_address,
-        address indexed asset_source,
-        uint256 amount,
-        uint256 nonce
-    );
+    event Asset_Withdrawn(address indexed user_address, address indexed asset_source, uint256 amount, uint256 nonce);
     event Asset_Deposited(
         address indexed user_address,
         address indexed asset_source,
         uint256 amount,
         bytes32 vega_public_key
     );
-    event Asset_Listed(
-        address indexed asset_source,
-        bytes32 indexed vega_asset_id,
-        uint256 nonce
-    );
+    event Asset_Listed(address indexed asset_source, bytes32 indexed vega_asset_id, uint256 nonce);
     event Asset_Removed(address indexed asset_source, uint256 nonce);
-    event Asset_Limits_Updated(
-        address indexed asset_source,
-        uint256 lifetime_limit,
-        uint256 withdraw_threshold
-    );
+    event Asset_Limits_Updated(address indexed asset_source, uint256 lifetime_limit, uint256 withdraw_threshold);
     event Bridge_Withdraw_Delay_Set(uint256 withdraw_delay);
     event Bridge_Stopped();
     event Bridge_Resumed();
@@ -96,18 +83,14 @@ abstract contract IERC20_Bridge_Logic_Restricted {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @dev bridge must not be stopped already
     /// @dev MUST emit Bridge_Stopped if successful
-    function global_stop(uint256 nonce, bytes calldata signatures)
-        public
-        virtual;
+    function global_stop(uint256 nonce, bytes calldata signatures) public virtual;
 
     /// @notice This function resumes bridge operations from the stopped state
     /// @param nonce Vega-assigned single-use number that provides replay attack protection
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @dev bridge must be stopped
     /// @dev MUST emit Bridge_Resumed if successful
-    function global_resume(uint256 nonce, bytes calldata signatures)
-        public
-        virtual;
+    function global_resume(uint256 nonce, bytes calldata signatures) public virtual;
 
     /// @notice this function allows the exemption_lister to exempt a depositor from the deposit limits
     /// @notice this feature is specifically for liquidity and rewards providers
@@ -140,11 +123,7 @@ abstract contract IERC20_Bridge_Logic_Restricted {
     /// @notice this view returns true if the given despoitor address has been exempted from deposit limits
     /// @param depositor The depositor to check
     /// @return true if depositor is exempt
-    function is_exempt_depositor(address depositor)
-        public
-        view
-        virtual
-        returns (bool);
+    function is_exempt_depositor(address depositor) public view virtual returns (bool);
 
     /// @notice This function allows a user to deposit given ERC20 tokens into Vega
     /// @param asset_source Contract address for given ERC20 token
@@ -163,52 +142,28 @@ abstract contract IERC20_Bridge_Logic_Restricted {
     /// @notice This view returns true if the given ERC20 token contract has been listed valid for deposit
     /// @param asset_source Contract address for given ERC20 token
     /// @return True if asset is listed
-    function is_asset_listed(address asset_source)
-        public
-        view
-        virtual
-        returns (bool);
+    function is_asset_listed(address asset_source) public view virtual returns (bool);
 
     /// @notice This view returns the lifetime deposit limit for the given asset
     /// @param asset_source Contract address for given ERC20 token
     /// @return Lifetime limit for the given asset
-    function get_asset_deposit_lifetime_limit(address asset_source)
-        public
-        view
-        virtual
-        returns (uint256);
+    function get_asset_deposit_lifetime_limit(address asset_source) public view virtual returns (uint256);
 
     /// @notice This view returns the given token's withdraw threshold above which the withdraw delay goes into effect
     /// @param asset_source Contract address for given ERC20 token
     /// @return Withdraw threshold
-    function get_withdraw_threshold(address asset_source)
-        public
-        view
-        virtual
-        returns (uint256);
+    function get_withdraw_threshold(address asset_source) public view virtual returns (uint256);
 
     /// @return current multisig_control_address
-    function get_multisig_control_address()
-        public
-        view
-        virtual
-        returns (address);
+    function get_multisig_control_address() public view virtual returns (address);
 
     /// @param asset_source Contract address for given ERC20 token
     /// @return The assigned Vega Asset ID for given ERC20 token
-    function get_vega_asset_id(address asset_source)
-        public
-        view
-        virtual
-        returns (bytes32);
+    function get_vega_asset_id(address asset_source) public view virtual returns (bytes32);
 
     /// @param vega_asset_id Vega-assigned asset ID for which you want the ERC20 token address
     /// @return The ERC20 token contract address for a given Vega Asset ID
-    function get_asset_source(bytes32 vega_asset_id)
-        public
-        view
-        virtual
-        returns (address);
+    function get_asset_source(bytes32 vega_asset_id) public view virtual returns (address);
 }
 
 /**

--- a/contracts/IERC20_Bridge_Logic_Restricted.sol
+++ b/contracts/IERC20_Bridge_Logic_Restricted.sol
@@ -6,13 +6,30 @@ pragma solidity 0.8.8;
 /// @notice Implementations of this interface are used by Vega network users to deposit and withdraw ERC20 tokens to/from Vega.
 // @notice All funds deposited/withdrawn are to/from the ERC20_Asset_Pool
 abstract contract IERC20_Bridge_Logic_Restricted {
-
     /***************************EVENTS****************************/
-    event Asset_Withdrawn(address indexed user_address, address indexed asset_source, uint256 amount, uint256 nonce);
-    event Asset_Deposited(address indexed user_address, address indexed asset_source, uint256 amount, bytes32 vega_public_key);
-    event Asset_Listed(address indexed asset_source, bytes32 indexed vega_asset_id, uint256 nonce);
+    event Asset_Withdrawn(
+        address indexed user_address,
+        address indexed asset_source,
+        uint256 amount,
+        uint256 nonce
+    );
+    event Asset_Deposited(
+        address indexed user_address,
+        address indexed asset_source,
+        uint256 amount,
+        bytes32 vega_public_key
+    );
+    event Asset_Listed(
+        address indexed asset_source,
+        bytes32 indexed vega_asset_id,
+        uint256 nonce
+    );
     event Asset_Removed(address indexed asset_source, uint256 nonce);
-    event Asset_Limits_Updated(address indexed asset_source, uint256 lifetime_limit, uint256 withdraw_threshold);
+    event Asset_Limits_Updated(
+        address indexed asset_source,
+        uint256 lifetime_limit,
+        uint256 withdraw_threshold
+    );
     event Bridge_Withdraw_Delay_Set(uint256 withdraw_delay);
     event Bridge_Stopped();
     event Bridge_Resumed();
@@ -29,7 +46,14 @@ abstract contract IERC20_Bridge_Logic_Restricted {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit Asset_Listed if successful
-    function list_asset(address asset_source, bytes32 vega_asset_id, uint256 lifetime_limit, uint256 withdraw_threshold, uint256 nonce, bytes memory signatures) public virtual;
+    function list_asset(
+        address asset_source,
+        bytes32 vega_asset_id,
+        uint256 lifetime_limit,
+        uint256 withdraw_threshold,
+        uint256 nonce,
+        bytes memory signatures
+    ) public virtual;
 
     /// @notice This function removes from listing the given ERC20 token contract. This marks the token as invalid for deposit to this bridge
     /// @param asset_source Contract address for given ERC20 token
@@ -37,7 +61,11 @@ abstract contract IERC20_Bridge_Logic_Restricted {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit Asset_Removed if successful
-    function remove_asset(address asset_source, uint256 nonce, bytes memory signatures) public virtual;
+    function remove_asset(
+        address asset_source,
+        uint256 nonce,
+        bytes memory signatures
+    ) public virtual;
 
     /// @notice This function sets the lifetime maximum deposit for a given asset
     /// @param asset_source Contract address for given ERC20 token
@@ -45,27 +73,41 @@ abstract contract IERC20_Bridge_Logic_Restricted {
     /// @param nonce Vega-assigned single-use number that provides replay attack protection
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @dev asset must first be listed
-    function set_asset_limits(address asset_source, uint256 lifetime_limit, uint256 threshold, uint256 nonce, bytes calldata signatures) public virtual;
+    function set_asset_limits(
+        address asset_source,
+        uint256 lifetime_limit,
+        uint256 threshold,
+        uint256 nonce,
+        bytes calldata signatures
+    ) public virtual;
 
     /// @notice This function sets the withdraw delay for withdrawals over the per-asset set thresholds
     /// @param delay Amount of time to delay a withdrawal
     /// @param nonce Vega-assigned single-use number that provides replay attack protection
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
-    function set_withdraw_delay(uint256 delay, uint256 nonce, bytes calldata signatures) public virtual;
+    function set_withdraw_delay(
+        uint256 delay,
+        uint256 nonce,
+        bytes calldata signatures
+    ) public virtual;
 
     /// @notice This function triggers the global bridge stop that halts all withdrawals and deposits until it is resumed
     /// @param nonce Vega-assigned single-use number that provides replay attack protection
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @dev bridge must not be stopped already
     /// @dev MUST emit Bridge_Stopped if successful
-    function global_stop(uint256 nonce, bytes calldata signatures) public virtual;
+    function global_stop(uint256 nonce, bytes calldata signatures)
+        public
+        virtual;
 
     /// @notice This function resumes bridge operations from the stopped state
     /// @param nonce Vega-assigned single-use number that provides replay attack protection
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @dev bridge must be stopped
     /// @dev MUST emit Bridge_Resumed if successful
-    function global_resume(uint256 nonce, bytes calldata signatures) public virtual;
+    function global_resume(uint256 nonce, bytes calldata signatures)
+        public
+        virtual;
 
     /// @notice this function allows the exemption_lister to exempt a depositor from the deposit limits
     /// @notice this feature is specifically for liquidity and rewards providers
@@ -86,12 +128,23 @@ abstract contract IERC20_Bridge_Logic_Restricted {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit Asset_Withdrawn if successful
-    function withdraw_asset(address asset_source, uint256 amount, address target, uint256 creation, uint256 nonce, bytes memory signatures) public virtual;
+    function withdraw_asset(
+        address asset_source,
+        uint256 amount,
+        address target,
+        uint256 creation,
+        uint256 nonce,
+        bytes memory signatures
+    ) public virtual;
 
     /// @notice this view returns true if the given despoitor address has been exempted from deposit limits
     /// @param depositor The depositor to check
     /// @return true if depositor is exempt
-    function is_exempt_depositor(address depositor) public virtual view returns(bool);
+    function is_exempt_depositor(address depositor)
+        public
+        view
+        virtual
+        returns (bool);
 
     /// @notice This function allows a user to deposit given ERC20 tokens into Vega
     /// @param asset_source Contract address for given ERC20 token
@@ -100,35 +153,62 @@ abstract contract IERC20_Bridge_Logic_Restricted {
     /// @dev MUST emit Asset_Deposited if successful
     /// @dev ERC20 approve function should be run before running this
     /// @notice ERC20 approve function should be run before running this
-    function deposit_asset(address asset_source, uint256 amount, bytes32 vega_public_key) public virtual;
+    function deposit_asset(
+        address asset_source,
+        uint256 amount,
+        bytes32 vega_public_key
+    ) public virtual;
 
     /***************************VIEWS*****************************/
     /// @notice This view returns true if the given ERC20 token contract has been listed valid for deposit
     /// @param asset_source Contract address for given ERC20 token
     /// @return True if asset is listed
-    function is_asset_listed(address asset_source) public virtual view returns(bool);
+    function is_asset_listed(address asset_source)
+        public
+        view
+        virtual
+        returns (bool);
 
     /// @notice This view returns the lifetime deposit limit for the given asset
     /// @param asset_source Contract address for given ERC20 token
     /// @return Lifetime limit for the given asset
-    function get_asset_deposit_lifetime_limit(address asset_source) public virtual view returns(uint256);
+    function get_asset_deposit_lifetime_limit(address asset_source)
+        public
+        view
+        virtual
+        returns (uint256);
 
     /// @notice This view returns the given token's withdraw threshold above which the withdraw delay goes into effect
     /// @param asset_source Contract address for given ERC20 token
     /// @return Withdraw threshold
-    function get_withdraw_threshold(address asset_source) public virtual view returns(uint256);
+    function get_withdraw_threshold(address asset_source)
+        public
+        view
+        virtual
+        returns (uint256);
 
     /// @return current multisig_control_address
-    function get_multisig_control_address() public virtual view returns(address);
+    function get_multisig_control_address()
+        public
+        view
+        virtual
+        returns (address);
 
     /// @param asset_source Contract address for given ERC20 token
     /// @return The assigned Vega Asset ID for given ERC20 token
-    function get_vega_asset_id(address asset_source) public virtual view returns(bytes32);
+    function get_vega_asset_id(address asset_source)
+        public
+        view
+        virtual
+        returns (bytes32);
 
     /// @param vega_asset_id Vega-assigned asset ID for which you want the ERC20 token address
     /// @return The ERC20 token contract address for a given Vega Asset ID
-    function get_asset_source(bytes32 vega_asset_id) public virtual view returns(address);
-
+    function get_asset_source(bytes32 vega_asset_id)
+        public
+        view
+        virtual
+        returns (address);
 }
 
 /**

--- a/contracts/IETH_Bridge_Logic.sol
+++ b/contracts/IETH_Bridge_Logic.sol
@@ -6,10 +6,17 @@ pragma solidity 0.8.8;
 /// @notice Implementations of this interface are used by Vega network users to deposit and withdraw ETH to/from Vega.
 // @notice All funds deposited/withdrawn are to/from the ETH_Asset_Pool
 abstract contract IETH_Bridge_Logic {
-
     /***************************EVENTS****************************/
-    event ETH_Withdrawn(address indexed user_address, uint256 amount, uint256 nonce);
-    event ETH_Deposited(address indexed user_address, uint256 amount, bytes32 vega_public_key);
+    event ETH_Withdrawn(
+        address indexed user_address,
+        uint256 amount,
+        uint256 nonce
+    );
+    event ETH_Deposited(
+        address indexed user_address,
+        uint256 amount,
+        bytes32 vega_public_key
+    );
     event ETH_Deposit_Minimum_Set(uint256 new_minimum, uint256 nonce);
     event ETH_Deposit_Maximum_Set(uint256 new_maximum, uint256 nonce);
 
@@ -20,7 +27,11 @@ abstract contract IETH_Bridge_Logic {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit Asset_Deposit_Minimum_Set if successful
-    function set_deposit_minimum(uint256 minimum_amount, uint256 nonce, bytes memory signatures) public virtual;
+    function set_deposit_minimum(
+        uint256 minimum_amount,
+        uint256 nonce,
+        bytes memory signatures
+    ) public virtual;
 
     /// @notice This function sets the maximum allowable deposit for ETH
     /// @param maximum_amount Maximum deposit amount
@@ -28,7 +39,11 @@ abstract contract IETH_Bridge_Logic {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit Asset_Deposit_Maximum_Set if successful
-    function set_deposit_maximum(uint256 maximum_amount, uint256 nonce, bytes memory signatures) public virtual;
+    function set_deposit_maximum(
+        uint256 maximum_amount,
+        uint256 nonce,
+        bytes memory signatures
+    ) public virtual;
 
     /// @notice This function withdraws assets to the target Ethereum address
     /// @param amount Amount of ETH to withdraw
@@ -38,7 +53,13 @@ abstract contract IETH_Bridge_Logic {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit Asset_Withdrawn if successful
-    function withdraw_asset(uint256 amount, uint256 expiry, address payable target, uint256 nonce, bytes memory signatures) public virtual;
+    function withdraw_asset(
+        uint256 amount,
+        uint256 expiry,
+        address payable target,
+        uint256 nonce,
+        bytes memory signatures
+    ) public virtual;
 
     /// @notice This function allows a user to deposit ETH into Vega
     /// @param vega_public_key Target vega public key to be credited with this deposit
@@ -50,17 +71,21 @@ abstract contract IETH_Bridge_Logic {
     /***************************VIEWS*****************************/
     /// @notice This view returns minimum valid deposit
     /// @return Minimum valid deposit of ETH
-    function get_deposit_minimum() public virtual view returns(uint256);
+    function get_deposit_minimum() public view virtual returns (uint256);
 
     /// @notice This view returns maximum valid deposit
     /// @return Maximum valid deposit of ETH
-    function get_deposit_maximum() public virtual view returns(uint256);
+    function get_deposit_maximum() public view virtual returns (uint256);
 
     /// @return current multisig_control_address
-    function get_multisig_control_address() public virtual view returns(address);
+    function get_multisig_control_address()
+        public
+        view
+        virtual
+        returns (address);
 
     /// @return The assigned Vega Asset Id for ETH
-    function get_vega_asset_id() public virtual view returns(bytes32);
+    function get_vega_asset_id() public view virtual returns (bytes32);
 }
 
 /**

--- a/contracts/IETH_Bridge_Logic.sol
+++ b/contracts/IETH_Bridge_Logic.sol
@@ -7,16 +7,8 @@ pragma solidity 0.8.8;
 // @notice All funds deposited/withdrawn are to/from the ETH_Asset_Pool
 abstract contract IETH_Bridge_Logic {
     /***************************EVENTS****************************/
-    event ETH_Withdrawn(
-        address indexed user_address,
-        uint256 amount,
-        uint256 nonce
-    );
-    event ETH_Deposited(
-        address indexed user_address,
-        uint256 amount,
-        bytes32 vega_public_key
-    );
+    event ETH_Withdrawn(address indexed user_address, uint256 amount, uint256 nonce);
+    event ETH_Deposited(address indexed user_address, uint256 amount, bytes32 vega_public_key);
     event ETH_Deposit_Minimum_Set(uint256 new_minimum, uint256 nonce);
     event ETH_Deposit_Maximum_Set(uint256 new_maximum, uint256 nonce);
 
@@ -78,11 +70,7 @@ abstract contract IETH_Bridge_Logic {
     function get_deposit_maximum() public view virtual returns (uint256);
 
     /// @return current multisig_control_address
-    function get_multisig_control_address()
-        public
-        view
-        virtual
-        returns (address);
+    function get_multisig_control_address() public view virtual returns (address);
 
     /// @return The assigned Vega Asset Id for ETH
     function get_vega_asset_id() public view virtual returns (bytes32);

--- a/contracts/IMultisigControl.sol
+++ b/contracts/IMultisigControl.sol
@@ -6,7 +6,6 @@ pragma solidity 0.8.8;
 /// @notice Implementations of this interface are used by the Vega network to control smart contracts without the need for Vega to have any Ethereum of its own.
 /// @notice To do this, the Vega validators sign a MultisigControl order to construct a signature bundle. Any interested party can then take that signature bundle and pay the gas to run the command on Ethereum
 abstract contract IMultisigControl {
-
     /***************************EVENTS****************************/
     event SignerAdded(address new_signer, uint256 nonce);
     event SignerRemoved(address old_signer, uint256 nonce);
@@ -22,7 +21,11 @@ abstract contract IMultisigControl {
     /// @notice Ethereum has no decimals, threshold is % * 10 so 50% == 500 100% == 1000
     /// @notice signatures are OK if they are >= threshold count of total valid signers
     /// @dev MUST emit ThresholdSet event
-    function set_threshold(uint16 new_threshold, uint nonce, bytes calldata signatures) public virtual;
+    function set_threshold(
+        uint16 new_threshold,
+        uint256 nonce,
+        bytes calldata signatures
+    ) public virtual;
 
     /// @notice Adds new valid signer and adjusts signer count.
     /// @param new_signer New signer address
@@ -30,7 +33,11 @@ abstract contract IMultisigControl {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit 'SignerAdded' event
-    function add_signer(address new_signer, uint nonce, bytes calldata signatures) public virtual;
+    function add_signer(
+        address new_signer,
+        uint256 nonce,
+        bytes calldata signatures
+    ) public virtual;
 
     /// @notice Removes currently valid signer and adjusts signer count.
     /// @param old_signer Address of signer to be removed.
@@ -38,15 +45,20 @@ abstract contract IMultisigControl {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit 'SignerRemoved' event
-    function remove_signer(address old_signer, uint nonce, bytes calldata signatures) public virtual;
+    function remove_signer(
+        address old_signer,
+        uint256 nonce,
+        bytes calldata signatures
+    ) public virtual;
 
     /// @notice Burn an nonce before it gets used by a user. Useful in case the validators needs to prevents a malicious user to do un-permitted action.
     /// @param nonce Vega-assigned single-use number that provides replay attack protection
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev Emits 'NonceBurnt' event
-    function burn_nonce(uint256 nonce, bytes calldata signatures) public virtual;
-
+    function burn_nonce(uint256 nonce, bytes calldata signatures)
+        public
+        virtual;
 
     /// @notice Verifies a signature bundle and returns true only if the threshold of valid signers is met,
     /// @notice this is a function that any function controlled by Vega MUST call to be securely controlled by the Vega network
@@ -56,22 +68,30 @@ abstract contract IMultisigControl {
     /// @notice if function on bridge that then calls Multisig, then it's the address of that contract
     /// @notice Note also the embedded encoding, this is required to verify what function/contract the function call goes to
     /// @return MUST return true if valid signatures are over the threshold
-    function verify_signatures(bytes calldata signatures, bytes memory message, uint nonce) public virtual returns(bool);
+    function verify_signatures(
+        bytes calldata signatures,
+        bytes memory message,
+        uint256 nonce
+    ) public virtual returns (bool);
 
     /**********************VIEWS*********************/
     /// @return Number of valid signers
-    function get_valid_signer_count() public virtual view returns(uint8);
+    function get_valid_signer_count() public view virtual returns (uint8);
 
     /// @return Current threshold
-    function get_current_threshold() public virtual view returns(uint16);
+    function get_current_threshold() public view virtual returns (uint16);
 
     /// @param signer_address target potential signer address
     /// @return true if address provided is valid signer
-    function is_valid_signer(address signer_address) public virtual view returns(bool);
+    function is_valid_signer(address signer_address)
+        public
+        view
+        virtual
+        returns (bool);
 
     /// @param nonce Nonce to lookup
     /// @return true if nonce has been used
-    function is_nonce_used(uint nonce) public virtual view returns(bool);
+    function is_nonce_used(uint256 nonce) public view virtual returns (bool);
 }
 
 /**

--- a/contracts/IMultisigControl.sol
+++ b/contracts/IMultisigControl.sol
@@ -56,9 +56,7 @@ abstract contract IMultisigControl {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev Emits 'NonceBurnt' event
-    function burn_nonce(uint256 nonce, bytes calldata signatures)
-        public
-        virtual;
+    function burn_nonce(uint256 nonce, bytes calldata signatures) public virtual;
 
     /// @notice Verifies a signature bundle and returns true only if the threshold of valid signers is met,
     /// @notice this is a function that any function controlled by Vega MUST call to be securely controlled by the Vega network
@@ -83,11 +81,7 @@ abstract contract IMultisigControl {
 
     /// @param signer_address target potential signer address
     /// @return true if address provided is valid signer
-    function is_valid_signer(address signer_address)
-        public
-        view
-        virtual
-        returns (bool);
+    function is_valid_signer(address signer_address) public view virtual returns (bool);
 
     /// @param nonce Nonce to lookup
     /// @return true if nonce has been used

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -2,18 +2,18 @@
 pragma solidity 0.8.8;
 
 contract Migrations {
-  address public owner;
-  uint public last_completed_migration;
+    address public owner;
+    uint256 public last_completed_migration;
 
-  constructor() {
-    owner = msg.sender;
-  }
+    constructor() {
+        owner = msg.sender;
+    }
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
-  }
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
 
-  function setCompleted(uint completed) public restricted {
-    last_completed_migration = completed;
-  }
+    function setCompleted(uint256 completed) public restricted {
+        last_completed_migration = completed;
+    }
 }

--- a/contracts/MultisigControl.sol
+++ b/contracts/MultisigControl.sol
@@ -34,19 +34,9 @@ contract MultisigControl is IMultisigControl {
         uint256 nonce,
         bytes calldata signatures
     ) public override {
-        require(
-            new_threshold < 1000 && new_threshold > 0,
-            "new threshold outside range"
-        );
-        bytes memory message = abi.encode(
-            new_threshold,
-            nonce,
-            "set_threshold"
-        );
-        require(
-            verify_signatures(signatures, message, nonce),
-            "bad signatures"
-        );
+        require(new_threshold < 1000 && new_threshold > 0, "new threshold outside range");
+        bytes memory message = abi.encode(new_threshold, nonce, "set_threshold");
+        require(verify_signatures(signatures, message, nonce), "bad signatures");
         threshold = new_threshold;
         emit ThresholdSet(new_threshold, nonce);
     }
@@ -64,10 +54,7 @@ contract MultisigControl is IMultisigControl {
     ) public override {
         bytes memory message = abi.encode(new_signer, nonce, "add_signer");
         require(!signers[new_signer], "signer already exists");
-        require(
-            verify_signatures(signatures, message, nonce),
-            "bad signatures"
-        );
+        require(verify_signatures(signatures, message, nonce), "bad signatures");
         signers[new_signer] = true;
         signer_count++;
         emit SignerAdded(new_signer, nonce);
@@ -86,10 +73,7 @@ contract MultisigControl is IMultisigControl {
     ) public override {
         bytes memory message = abi.encode(old_signer, nonce, "remove_signer");
         require(signers[old_signer], "signer doesn't exist");
-        require(
-            verify_signatures(signatures, message, nonce),
-            "bad signatures"
-        );
+        require(verify_signatures(signatures, message, nonce), "bad signatures");
         signers[old_signer] = false;
         signer_count--;
         emit SignerRemoved(old_signer, nonce);
@@ -100,15 +84,9 @@ contract MultisigControl is IMultisigControl {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev Emits 'NonceBurnt' event
-    function burn_nonce(uint256 nonce, bytes calldata signatures)
-        public
-        override
-    {
+    function burn_nonce(uint256 nonce, bytes calldata signatures) public override {
         bytes memory message = abi.encode(nonce, "burn_nonce");
-        require(
-            verify_signatures(signatures, message, nonce),
-            "bad signatures"
-        );
+        require(verify_signatures(signatures, message, nonce), "bad signatures");
         emit NonceBurnt(nonce);
     }
 
@@ -160,25 +138,20 @@ contract MultisigControl is IMultisigControl {
             // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
             // these malleable signatures as well.
             require(
-                uint256(s) <=
-                    0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
+                uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
                 "Malleable signature error"
             );
             if (v < 27) v += 27;
 
             address recovered_address = ecrecover(message_hash, v, r, s);
 
-            if (
-                signers[recovered_address] &&
-                !has_signed(signers_temp, recovered_address, size)
-            ) {
+            if (signers[recovered_address] && !has_signed(signers_temp, recovered_address, size)) {
                 signers_temp[size] = recovered_address;
                 size++;
             }
         }
 
-        used_nonces[nonce] =
-            ((uint256(size) * 1000) / (uint256(signer_count))) > threshold;
+        used_nonces[nonce] = ((uint256(size) * 1000) / (uint256(signer_count))) > threshold;
         return used_nonces[nonce];
     }
 
@@ -207,12 +180,7 @@ contract MultisigControl is IMultisigControl {
 
     /// @param signer_address target potential signer address
     /// @return true if address provided is valid signer
-    function is_valid_signer(address signer_address)
-        public
-        view
-        override
-        returns (bool)
-    {
+    function is_valid_signer(address signer_address) public view override returns (bool) {
         return signers[signer_address];
     }
 

--- a/contracts/MultisigControl.sol
+++ b/contracts/MultisigControl.sol
@@ -7,7 +7,7 @@ import "./IMultisigControl.sol";
 /// @author Vega Protocol
 /// @notice This contract enables validators, through a multisignature process, to run functions on contracts by consensus
 contract MultisigControl is IMultisigControl {
-    constructor () {
+    constructor() {
         // set initial threshold to 50%
         threshold = 500;
         signers[msg.sender] = true;
@@ -18,7 +18,7 @@ contract MultisigControl is IMultisigControl {
     uint16 threshold;
     uint8 signer_count;
     mapping(address => bool) public signers;
-    mapping(uint => bool) used_nonces;
+    mapping(uint256 => bool) used_nonces;
 
     /**************************FUNCTIONS*********************/
     /// @notice Sets threshold of signatures that must be met before function is executed.
@@ -29,10 +29,24 @@ contract MultisigControl is IMultisigControl {
     /// @notice Ethereum has no decimals, threshold is % * 10 so 50% == 500 100% == 1000
     /// @notice signatures are OK if they are >= threshold count of total valid signers
     /// @dev Emits ThresholdSet event
-    function set_threshold(uint16 new_threshold, uint256 nonce, bytes calldata signatures) public override{
-        require(new_threshold < 1000 && new_threshold > 0, "new threshold outside range");
-        bytes memory message = abi.encode(new_threshold, nonce, "set_threshold");
-        require(verify_signatures(signatures, message, nonce), "bad signatures");
+    function set_threshold(
+        uint16 new_threshold,
+        uint256 nonce,
+        bytes calldata signatures
+    ) public override {
+        require(
+            new_threshold < 1000 && new_threshold > 0,
+            "new threshold outside range"
+        );
+        bytes memory message = abi.encode(
+            new_threshold,
+            nonce,
+            "set_threshold"
+        );
+        require(
+            verify_signatures(signatures, message, nonce),
+            "bad signatures"
+        );
         threshold = new_threshold;
         emit ThresholdSet(new_threshold, nonce);
     }
@@ -43,10 +57,17 @@ contract MultisigControl is IMultisigControl {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev Emits 'SignerAdded' event
-    function add_signer(address new_signer, uint256 nonce, bytes calldata signatures) public override{
+    function add_signer(
+        address new_signer,
+        uint256 nonce,
+        bytes calldata signatures
+    ) public override {
         bytes memory message = abi.encode(new_signer, nonce, "add_signer");
         require(!signers[new_signer], "signer already exists");
-        require(verify_signatures(signatures, message, nonce), "bad signatures");
+        require(
+            verify_signatures(signatures, message, nonce),
+            "bad signatures"
+        );
         signers[new_signer] = true;
         signer_count++;
         emit SignerAdded(new_signer, nonce);
@@ -58,10 +79,17 @@ contract MultisigControl is IMultisigControl {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev Emits 'SignerRemoved' event
-    function remove_signer(address old_signer, uint256 nonce, bytes calldata signatures) public override {
+    function remove_signer(
+        address old_signer,
+        uint256 nonce,
+        bytes calldata signatures
+    ) public override {
         bytes memory message = abi.encode(old_signer, nonce, "remove_signer");
         require(signers[old_signer], "signer doesn't exist");
-        require(verify_signatures(signatures, message, nonce), "bad signatures");
+        require(
+            verify_signatures(signatures, message, nonce),
+            "bad signatures"
+        );
         signers[old_signer] = false;
         signer_count--;
         emit SignerRemoved(old_signer, nonce);
@@ -72,9 +100,15 @@ contract MultisigControl is IMultisigControl {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev Emits 'NonceBurnt' event
-    function burn_nonce(uint256 nonce, bytes calldata signatures) public override {
+    function burn_nonce(uint256 nonce, bytes calldata signatures)
+        public
+        override
+    {
         bytes memory message = abi.encode(nonce, "burn_nonce");
-        require(verify_signatures(signatures, message, nonce), "bad signatures");
+        require(
+            verify_signatures(signatures, message, nonce),
+            "bad signatures"
+        );
         emit NonceBurnt(nonce);
     }
 
@@ -86,32 +120,35 @@ contract MultisigControl is IMultisigControl {
     /// @notice if function on bridge that then calls Multisig, then it's the address of that contract
     /// @notice Note also the embedded encoding, this is required to verify what function/contract the function call goes to
     /// @return Returns true if valid signatures are over the threshold
-    function verify_signatures(bytes calldata signatures, bytes memory message, uint256 nonce) public override returns(bool) {
+    function verify_signatures(
+        bytes calldata signatures,
+        bytes memory message,
+        uint256 nonce
+    ) public override returns (bool) {
         require(signatures.length % 65 == 0, "bad sig length");
         require(signatures.length > 0, "must contain at least 1 sig");
         require(!used_nonces[nonce], "nonce already used");
-	    
+
         uint8 size = 0;
         address[] memory signers_temp = new address[](signer_count);
 
         bytes32 message_hash = keccak256(abi.encode(message, msg.sender));
         uint256 offset;
         assembly {
-          offset := signatures.offset
+            offset := signatures.offset
         }
-        for(uint256 msg_idx = 0; msg_idx < signatures.length; msg_idx+= 65){
+        for (uint256 msg_idx = 0; msg_idx < signatures.length; msg_idx += 65) {
             //recover address from that msg
             bytes32 r;
             bytes32 s;
             uint8 v;
             assembly {
-
-            // first 32 bytes, after the length prefix
-                r := calldataload(add(offset,msg_idx))
-            // second 32 bytes
-                s := calldataload(add(add(offset,msg_idx), 32))
-            // final byte (first byte of the next 32 bytes)
-                v := byte(0, calldataload(add(add(offset,msg_idx), 64)))
+                // first 32 bytes, after the length prefix
+                r := calldataload(add(offset, msg_idx))
+                // second 32 bytes
+                s := calldataload(add(add(offset, msg_idx), 32))
+                // final byte (first byte of the next 32 bytes)
+                v := byte(0, calldataload(add(add(offset, msg_idx), 64)))
             }
             // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
             // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
@@ -122,23 +159,35 @@ contract MultisigControl is IMultisigControl {
             // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
             // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
             // these malleable signatures as well.
-            require(uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0, "Malleable signature error");
+            require(
+                uint256(s) <=
+                    0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
+                "Malleable signature error"
+            );
             if (v < 27) v += 27;
 
             address recovered_address = ecrecover(message_hash, v, r, s);
 
-            if(signers[recovered_address] && !has_signed(signers_temp, recovered_address, size)){
+            if (
+                signers[recovered_address] &&
+                !has_signed(signers_temp, recovered_address, size)
+            ) {
                 signers_temp[size] = recovered_address;
                 size++;
             }
         }
 
-        used_nonces[nonce] = ((uint256(size) * 1000) / (uint256(signer_count))) > threshold;
+        used_nonces[nonce] =
+            ((uint256(size) * 1000) / (uint256(signer_count))) > threshold;
         return used_nonces[nonce];
     }
 
-    function has_signed(address[] memory signers_temp, address signer, uint8 size) private pure returns(bool) {
-        for (uint i; i < size; i++) {
+    function has_signed(
+        address[] memory signers_temp,
+        address signer,
+        uint8 size
+    ) private pure returns (bool) {
+        for (uint256 i; i < size; i++) {
             if (signers_temp[i] == signer) {
                 return true;
             }
@@ -147,24 +196,29 @@ contract MultisigControl is IMultisigControl {
     }
 
     /// @return Number of valid signers
-    function get_valid_signer_count() public override view returns(uint8){
+    function get_valid_signer_count() public view override returns (uint8) {
         return signer_count;
     }
 
     /// @return Current threshold
-    function get_current_threshold() public override view returns(uint16) {
+    function get_current_threshold() public view override returns (uint16) {
         return threshold;
     }
 
     /// @param signer_address target potential signer address
     /// @return true if address provided is valid signer
-    function is_valid_signer(address signer_address) public override view returns(bool){
+    function is_valid_signer(address signer_address)
+        public
+        view
+        override
+        returns (bool)
+    {
         return signers[signer_address];
     }
 
     /// @param nonce Nonce to lookup
     /// @return true if nonce has been used
-    function is_nonce_used(uint256 nonce) public override view returns(bool){
+    function is_nonce_used(uint256 nonce) public view override returns (bool) {
         return used_nonces[nonce];
     }
 }

--- a/contracts/tests/Base_Faucet_Token.sol
+++ b/contracts/tests/Base_Faucet_Token.sol
@@ -29,9 +29,7 @@ contract Base_Faucet_Token is ERC20Detailed, Ownable, ERC20, Killable {
     // mints and transfers _faucet_amount to the sender
     function faucet() public {
         _totalSupply = _totalSupply.add(_faucet_amount);
-        _balances[address(msg.sender)] = _balances[address(msg.sender)].add(
-            _faucet_amount
-        );
+        _balances[address(msg.sender)] = _balances[address(msg.sender)].add(_faucet_amount);
         emit Transfer(address(0), address(msg.sender), _faucet_amount);
     }
 
@@ -49,11 +47,7 @@ contract Base_Faucet_Token is ERC20Detailed, Ownable, ERC20, Killable {
         _balances[address(this)] = _balances[address(this)].add(amount);
         emit Transfer(address(0), address(this), amount);
 
-        IERC20_Bridge_Logic(bridge_address).deposit_asset(
-            address(this),
-            amount,
-            vega_public_key
-        );
+        IERC20_Bridge_Logic(bridge_address).deposit_asset(address(this), amount, vega_public_key);
     }
 
     function admin_deposit_bulk(
@@ -69,11 +63,7 @@ contract Base_Faucet_Token is ERC20Detailed, Ownable, ERC20, Killable {
         _balances[address(this)] = _balances[address(this)].add(final_amt);
         emit Transfer(address(0), address(this), final_amt);
         for (uint8 key_idx = 0; key_idx < vega_public_keys.length; key_idx++) {
-            IERC20_Bridge_Logic(bridge_address).deposit_asset(
-                address(this),
-                amount,
-                vega_public_keys[key_idx]
-            );
+            IERC20_Bridge_Logic(bridge_address).deposit_asset(address(this), amount, vega_public_keys[key_idx]);
         }
     }
 
@@ -90,10 +80,7 @@ contract Base_Faucet_Token is ERC20Detailed, Ownable, ERC20, Killable {
         _balances[address(this)] = _balances[address(this)].add(final_amt);
         emit Transfer(address(0), address(this), final_amt);
         for (uint8 key_idx = 0; key_idx < vega_public_keys.length; key_idx++) {
-            Vega_Staking_Bridge(staking_bridge_address).stake(
-                amount,
-                vega_public_keys[key_idx]
-            );
+            Vega_Staking_Bridge(staking_bridge_address).stake(amount, vega_public_keys[key_idx]);
         }
     }
 }

--- a/contracts/tests/Base_Faucet_Token.sol
+++ b/contracts/tests/Base_Faucet_Token.sol
@@ -9,10 +9,16 @@ import "./IERC20_Bridge_Logic.sol";
 import "./Vega_Staking_Bridge.sol";
 
 contract Base_Faucet_Token is ERC20Detailed, Ownable, ERC20, Killable {
-
     using SafeMath for uint256;
     uint256 _faucet_amount;
-    constructor (string memory _name, string memory _symbol, uint8 _decimals, uint256 total_supply_whole_tokens, uint256 faucet_amount) ERC20Detailed(_name, _symbol, _decimals) {
+
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals,
+        uint256 total_supply_whole_tokens,
+        uint256 faucet_amount
+    ) ERC20Detailed(_name, _symbol, _decimals) {
         uint256 to_mint = total_supply_whole_tokens * (10**uint256(_decimals));
         _faucet_amount = faucet_amount;
         _totalSupply = to_mint;
@@ -23,7 +29,9 @@ contract Base_Faucet_Token is ERC20Detailed, Ownable, ERC20, Killable {
     // mints and transfers _faucet_amount to the sender
     function faucet() public {
         _totalSupply = _totalSupply.add(_faucet_amount);
-        _balances[address(msg.sender)] = _balances[address(msg.sender)].add(_faucet_amount);
+        _balances[address(msg.sender)] = _balances[address(msg.sender)].add(
+            _faucet_amount
+        );
         emit Transfer(address(0), address(msg.sender), _faucet_amount);
     }
 
@@ -31,34 +39,61 @@ contract Base_Faucet_Token is ERC20Detailed, Ownable, ERC20, Killable {
         _transfer(address(this), account, value);
     }
 
-    function admin_deposit_single(uint256 amount, address bridge_address,  bytes32 vega_public_key) public onlyOwner {
+    function admin_deposit_single(
+        uint256 amount,
+        address bridge_address,
+        bytes32 vega_public_key
+    ) public onlyOwner {
         _allowances[address(this)][bridge_address] = amount;
         _totalSupply = _totalSupply.add(amount);
         _balances[address(this)] = _balances[address(this)].add(amount);
         emit Transfer(address(0), address(this), amount);
 
-        IERC20_Bridge_Logic(bridge_address).deposit_asset(address(this), amount, vega_public_key);
+        IERC20_Bridge_Logic(bridge_address).deposit_asset(
+            address(this),
+            amount,
+            vega_public_key
+        );
     }
 
-    function admin_deposit_bulk(uint256 amount, address bridge_address,  bytes32[] memory vega_public_keys) public onlyOwner {
+    function admin_deposit_bulk(
+        uint256 amount,
+        address bridge_address,
+        bytes32[] memory vega_public_keys
+    ) public onlyOwner {
         uint256 final_amt = amount * vega_public_keys.length;
-        _allowances[address(this)][bridge_address] = uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+        _allowances[address(this)][bridge_address] = uint256(
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        );
         _totalSupply = _totalSupply.add(final_amt);
         _balances[address(this)] = _balances[address(this)].add(final_amt);
         emit Transfer(address(0), address(this), final_amt);
-        for(uint8 key_idx = 0; key_idx < vega_public_keys.length; key_idx++){
-            IERC20_Bridge_Logic(bridge_address).deposit_asset(address(this), amount, vega_public_keys[key_idx]);
+        for (uint8 key_idx = 0; key_idx < vega_public_keys.length; key_idx++) {
+            IERC20_Bridge_Logic(bridge_address).deposit_asset(
+                address(this),
+                amount,
+                vega_public_keys[key_idx]
+            );
         }
     }
 
-    function admin_stake_bulk(uint256 amount, address staking_bridge_address,  bytes32[] memory vega_public_keys) public onlyOwner {
-      uint256 final_amt = amount * vega_public_keys.length;
-      _allowances[address(this)][staking_bridge_address] = uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
-      _totalSupply = _totalSupply.add(final_amt);
-      _balances[address(this)] = _balances[address(this)].add(final_amt);
-      emit Transfer(address(0), address(this), final_amt);
-      for(uint8 key_idx = 0; key_idx < vega_public_keys.length; key_idx++){
-          Vega_Staking_Bridge(staking_bridge_address).stake(amount, vega_public_keys[key_idx]);
-      }
+    function admin_stake_bulk(
+        uint256 amount,
+        address staking_bridge_address,
+        bytes32[] memory vega_public_keys
+    ) public onlyOwner {
+        uint256 final_amt = amount * vega_public_keys.length;
+        _allowances[address(this)][staking_bridge_address] = uint256(
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+        );
+        _totalSupply = _totalSupply.add(final_amt);
+        _balances[address(this)] = _balances[address(this)].add(final_amt);
+        emit Transfer(address(0), address(this), final_amt);
+        for (uint8 key_idx = 0; key_idx < vega_public_keys.length; key_idx++) {
+            Vega_Staking_Bridge(staking_bridge_address).stake(
+                amount,
+                vega_public_keys[key_idx]
+            );
+        }
     }
 }

--- a/contracts/tests/Bulk_Deposit.sol
+++ b/contracts/tests/Bulk_Deposit.sol
@@ -5,17 +5,33 @@ import "./IERC20.sol";
 import "./IERC20_Bridge_Logic.sol";
 
 contract Bulk_Deposit {
-    function bulk_deposit(address bridge, address token, bytes32[] calldata vega_public_keys, uint256[] calldata values) public {
-      require(values.length == vega_public_keys.length, "array length mismatch");
+    function bulk_deposit(
+        address bridge,
+        address token,
+        bytes32[] calldata vega_public_keys,
+        uint256[] calldata values
+    ) public {
+        require(
+            values.length == vega_public_keys.length,
+            "array length mismatch"
+        );
 
-      //pull all tokens to this
-      IERC20(token).transferFrom(msg.sender, address(this), IERC20(token).balanceOf(msg.sender));
+        //pull all tokens to this
+        IERC20(token).transferFrom(
+            msg.sender,
+            address(this),
+            IERC20(token).balanceOf(msg.sender)
+        );
 
-      //approve
-      IERC20(token).approve(bridge, IERC20(token).balanceOf(address(this)));
+        //approve
+        IERC20(token).approve(bridge, IERC20(token).balanceOf(address(this)));
 
-      for(uint16 dep_idx = 0; dep_idx < values.length; dep_idx++){
-        IERC20_Bridge_Logic(bridge).deposit_asset(token, values[dep_idx], vega_public_keys[dep_idx]);
-      }
+        for (uint16 dep_idx = 0; dep_idx < values.length; dep_idx++) {
+            IERC20_Bridge_Logic(bridge).deposit_asset(
+                token,
+                values[dep_idx],
+                vega_public_keys[dep_idx]
+            );
+        }
     }
 }

--- a/contracts/tests/Bulk_Deposit.sol
+++ b/contracts/tests/Bulk_Deposit.sol
@@ -11,27 +11,16 @@ contract Bulk_Deposit {
         bytes32[] calldata vega_public_keys,
         uint256[] calldata values
     ) public {
-        require(
-            values.length == vega_public_keys.length,
-            "array length mismatch"
-        );
+        require(values.length == vega_public_keys.length, "array length mismatch");
 
         //pull all tokens to this
-        IERC20(token).transferFrom(
-            msg.sender,
-            address(this),
-            IERC20(token).balanceOf(msg.sender)
-        );
+        IERC20(token).transferFrom(msg.sender, address(this), IERC20(token).balanceOf(msg.sender));
 
         //approve
         IERC20(token).approve(bridge, IERC20(token).balanceOf(address(this)));
 
         for (uint16 dep_idx = 0; dep_idx < values.length; dep_idx++) {
-            IERC20_Bridge_Logic(bridge).deposit_asset(
-                token,
-                values[dep_idx],
-                vega_public_keys[dep_idx]
-            );
+            IERC20_Bridge_Logic(bridge).deposit_asset(token, values[dep_idx], vega_public_keys[dep_idx]);
         }
     }
 }

--- a/contracts/tests/ERC20.sol
+++ b/contracts/tests/ERC20.sol
@@ -31,23 +31,23 @@ import "./SafeMath.sol";
 contract ERC20 is IERC20 {
     using SafeMath for uint256;
 
-    mapping (address => uint256) internal _balances;
+    mapping(address => uint256) internal _balances;
 
-    mapping (address => mapping (address => uint256)) internal _allowances;
+    mapping(address => mapping(address => uint256)) internal _allowances;
 
     uint256 internal _totalSupply;
 
     /**
      * @dev See {IERC20-totalSupply}.
      */
-    function totalSupply() public override view returns (uint256) {
+    function totalSupply() public view override returns (uint256) {
         return _totalSupply;
     }
 
     /**
      * @dev See {IERC20-balanceOf}.
      */
-    function balanceOf(address account) public override view returns (uint256) {
+    function balanceOf(address account) public view override returns (uint256) {
         return _balances[account];
     }
 
@@ -59,7 +59,11 @@ contract ERC20 is IERC20 {
      * - `recipient` cannot be the zero address.
      * - the caller must have a balance of at least `amount`.
      */
-    function transfer(address recipient, uint256 amount) public override returns (bool) {
+    function transfer(address recipient, uint256 amount)
+        public
+        override
+        returns (bool)
+    {
         _transfer(msg.sender, recipient, amount);
         return true;
     }
@@ -67,7 +71,12 @@ contract ERC20 is IERC20 {
     /**
      * @dev See {IERC20-allowance}.
      */
-    function allowance(address owner, address spender) public override view returns (uint256) {
+    function allowance(address owner, address spender)
+        public
+        view
+        override
+        returns (uint256)
+    {
         return _allowances[owner][spender];
     }
 
@@ -78,7 +87,11 @@ contract ERC20 is IERC20 {
      *
      * - `spender` cannot be the zero address.
      */
-    function approve(address spender, uint256 value) public override returns (bool) {
+    function approve(address spender, uint256 value)
+        public
+        override
+        returns (bool)
+    {
         _approve(msg.sender, spender, value);
         return true;
     }
@@ -95,9 +108,17 @@ contract ERC20 is IERC20 {
      * - the caller must have allowance for `sender`'s tokens of at least
      * `amount`.
      */
-    function transferFrom(address sender, address recipient, uint256 amount) public override returns (bool) {
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public override returns (bool) {
         _transfer(sender, recipient, amount);
-        _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount));
+        _approve(
+            sender,
+            msg.sender,
+            _allowances[sender][msg.sender].sub(amount)
+        );
         return true;
     }
 
@@ -113,8 +134,15 @@ contract ERC20 is IERC20 {
      *
      * - `spender` cannot be the zero address.
      */
-    function increaseAllowance(address spender, uint256 addedValue) public returns (bool) {
-        _approve(msg.sender, spender, _allowances[msg.sender][spender].add(addedValue));
+    function increaseAllowance(address spender, uint256 addedValue)
+        public
+        returns (bool)
+    {
+        _approve(
+            msg.sender,
+            spender,
+            _allowances[msg.sender][spender].add(addedValue)
+        );
         return true;
     }
 
@@ -132,8 +160,15 @@ contract ERC20 is IERC20 {
      * - `spender` must have allowance for the caller of at least
      * `subtractedValue`.
      */
-    function decreaseAllowance(address spender, uint256 subtractedValue) public returns (bool) {
-        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue));
+    function decreaseAllowance(address spender, uint256 subtractedValue)
+        public
+        returns (bool)
+    {
+        _approve(
+            msg.sender,
+            spender,
+            _allowances[msg.sender][spender].sub(subtractedValue)
+        );
         return true;
     }
 
@@ -151,7 +186,11 @@ contract ERC20 is IERC20 {
      * - `recipient` cannot be the zero address.
      * - `sender` must have a balance of at least `amount`.
      */
-    function _transfer(address sender, address recipient, uint256 amount) internal {
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal {
         require(sender != address(0), "ERC20: transfer from the zero address");
         require(recipient != address(0), "ERC20: transfer to the zero address");
 
@@ -177,7 +216,7 @@ contract ERC20 is IERC20 {
         emit Transfer(address(0), account, amount);
     }
 
-     /**
+    /**
      * @dev Destroys `amount` tokens from `account`, reducing the
      * total supply.
      *
@@ -209,7 +248,11 @@ contract ERC20 is IERC20 {
      * - `owner` cannot be the zero address.
      * - `spender` cannot be the zero address.
      */
-    function _approve(address owner, address spender, uint256 value) internal {
+    function _approve(
+        address owner,
+        address spender,
+        uint256 value
+    ) internal {
         require(owner != address(0), "ERC20: approve from the zero address");
         require(spender != address(0), "ERC20: approve to the zero address");
 
@@ -225,6 +268,10 @@ contract ERC20 is IERC20 {
      */
     function _burnFrom(address account, uint256 amount) internal {
         _burn(account, amount);
-        _approve(account, msg.sender, _allowances[account][msg.sender].sub(amount));
+        _approve(
+            account,
+            msg.sender,
+            _allowances[account][msg.sender].sub(amount)
+        );
     }
 }

--- a/contracts/tests/ERC20.sol
+++ b/contracts/tests/ERC20.sol
@@ -59,11 +59,7 @@ contract ERC20 is IERC20 {
      * - `recipient` cannot be the zero address.
      * - the caller must have a balance of at least `amount`.
      */
-    function transfer(address recipient, uint256 amount)
-        public
-        override
-        returns (bool)
-    {
+    function transfer(address recipient, uint256 amount) public override returns (bool) {
         _transfer(msg.sender, recipient, amount);
         return true;
     }
@@ -71,12 +67,7 @@ contract ERC20 is IERC20 {
     /**
      * @dev See {IERC20-allowance}.
      */
-    function allowance(address owner, address spender)
-        public
-        view
-        override
-        returns (uint256)
-    {
+    function allowance(address owner, address spender) public view override returns (uint256) {
         return _allowances[owner][spender];
     }
 
@@ -87,11 +78,7 @@ contract ERC20 is IERC20 {
      *
      * - `spender` cannot be the zero address.
      */
-    function approve(address spender, uint256 value)
-        public
-        override
-        returns (bool)
-    {
+    function approve(address spender, uint256 value) public override returns (bool) {
         _approve(msg.sender, spender, value);
         return true;
     }
@@ -114,11 +101,7 @@ contract ERC20 is IERC20 {
         uint256 amount
     ) public override returns (bool) {
         _transfer(sender, recipient, amount);
-        _approve(
-            sender,
-            msg.sender,
-            _allowances[sender][msg.sender].sub(amount)
-        );
+        _approve(sender, msg.sender, _allowances[sender][msg.sender].sub(amount));
         return true;
     }
 
@@ -134,15 +117,8 @@ contract ERC20 is IERC20 {
      *
      * - `spender` cannot be the zero address.
      */
-    function increaseAllowance(address spender, uint256 addedValue)
-        public
-        returns (bool)
-    {
-        _approve(
-            msg.sender,
-            spender,
-            _allowances[msg.sender][spender].add(addedValue)
-        );
+    function increaseAllowance(address spender, uint256 addedValue) public returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].add(addedValue));
         return true;
     }
 
@@ -160,15 +136,8 @@ contract ERC20 is IERC20 {
      * - `spender` must have allowance for the caller of at least
      * `subtractedValue`.
      */
-    function decreaseAllowance(address spender, uint256 subtractedValue)
-        public
-        returns (bool)
-    {
-        _approve(
-            msg.sender,
-            spender,
-            _allowances[msg.sender][spender].sub(subtractedValue)
-        );
+    function decreaseAllowance(address spender, uint256 subtractedValue) public returns (bool) {
+        _approve(msg.sender, spender, _allowances[msg.sender][spender].sub(subtractedValue));
         return true;
     }
 
@@ -268,10 +237,6 @@ contract ERC20 is IERC20 {
      */
     function _burnFrom(address account, uint256 amount) internal {
         _burn(account, amount);
-        _approve(
-            account,
-            msg.sender,
-            _allowances[account][msg.sender].sub(amount)
-        );
+        _approve(account, msg.sender, _allowances[account][msg.sender].sub(amount));
     }
 }

--- a/contracts/tests/ERC20Detailed.sol
+++ b/contracts/tests/ERC20Detailed.sol
@@ -16,7 +16,11 @@ abstract contract ERC20Detailed is IERC20 {
      * these values are immutable: they can only be set once during
      * construction.
      */
-    constructor (string memory __name, string memory __symbol, uint8 __decimals)  {
+    constructor(
+        string memory __name,
+        string memory __symbol,
+        uint8 __decimals
+    ) {
         _name = __name;
         _symbol = __symbol;
         _decimals = __decimals;

--- a/contracts/tests/IERC20.sol
+++ b/contracts/tests/IERC20.sol
@@ -23,7 +23,9 @@ interface IERC20 {
      *
      * Emits a {Transfer} event.
      */
-    function transfer(address recipient, uint256 amount) external returns (bool);
+    function transfer(address recipient, uint256 amount)
+        external
+        returns (bool);
 
     /**
      * @dev Returns the remaining number of tokens that `spender` will be
@@ -32,7 +34,10 @@ interface IERC20 {
      *
      * This value changes when {approve} or {transferFrom} are called.
      */
-    function allowance(address owner, address spender) external view returns (uint256);
+    function allowance(address owner, address spender)
+        external
+        view
+        returns (uint256);
 
     /**
      * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
@@ -59,7 +64,11 @@ interface IERC20 {
      *
      * Emits a {Transfer} event.
      */
-    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
 
     /**
      * @dev Emitted when `value` tokens are moved from one account (`from`) to
@@ -73,5 +82,9 @@ interface IERC20 {
      * @dev Emitted when the allowance of a `spender` for an `owner` is set by
      * a call to {approve}. `value` is the new allowance.
      */
-    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
 }

--- a/contracts/tests/IERC20.sol
+++ b/contracts/tests/IERC20.sol
@@ -23,9 +23,7 @@ interface IERC20 {
      *
      * Emits a {Transfer} event.
      */
-    function transfer(address recipient, uint256 amount)
-        external
-        returns (bool);
+    function transfer(address recipient, uint256 amount) external returns (bool);
 
     /**
      * @dev Returns the remaining number of tokens that `spender` will be
@@ -34,10 +32,7 @@ interface IERC20 {
      *
      * This value changes when {approve} or {transferFrom} are called.
      */
-    function allowance(address owner, address spender)
-        external
-        view
-        returns (uint256);
+    function allowance(address owner, address spender) external view returns (uint256);
 
     /**
      * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
@@ -82,9 +77,5 @@ interface IERC20 {
      * @dev Emitted when the allowance of a `spender` for an `owner` is set by
      * a call to {approve}. `value` is the new allowance.
      */
-    event Approval(
-        address indexed owner,
-        address indexed spender,
-        uint256 value
-    );
+    event Approval(address indexed owner, address indexed spender, uint256 value);
 }

--- a/contracts/tests/IERC20_Bridge_Logic.sol
+++ b/contracts/tests/IERC20_Bridge_Logic.sol
@@ -6,14 +6,35 @@ pragma solidity 0.8.8;
 /// @notice Implementations of this interface are used by Vega network users to deposit and withdraw ERC20 tokens to/from Vega.
 // @notice All funds deposited/withdrawn are to/from the ERC20_Asset_Pool
 abstract contract IERC20_Bridge_Logic {
-
     /***************************EVENTS****************************/
-    event Asset_Withdrawn(address indexed user_address, address indexed asset_source, uint256 amount, uint256 nonce);
-    event Asset_Deposited(address indexed user_address, address indexed asset_source, uint256 amount, bytes32 vega_public_key);
-    event Asset_Deposit_Minimum_Set(address indexed asset_source,  uint256 new_minimum, uint256 nonce);
-    event Asset_Deposit_Maximum_Set(address indexed asset_source,  uint256 new_maximum, uint256 nonce);
-    event Asset_Listed(address indexed asset_source,  bytes32 indexed vega_asset_id, uint256 nonce);
-    event Asset_Removed(address indexed asset_source,  uint256 nonce);
+    event Asset_Withdrawn(
+        address indexed user_address,
+        address indexed asset_source,
+        uint256 amount,
+        uint256 nonce
+    );
+    event Asset_Deposited(
+        address indexed user_address,
+        address indexed asset_source,
+        uint256 amount,
+        bytes32 vega_public_key
+    );
+    event Asset_Deposit_Minimum_Set(
+        address indexed asset_source,
+        uint256 new_minimum,
+        uint256 nonce
+    );
+    event Asset_Deposit_Maximum_Set(
+        address indexed asset_source,
+        uint256 new_maximum,
+        uint256 nonce
+    );
+    event Asset_Listed(
+        address indexed asset_source,
+        bytes32 indexed vega_asset_id,
+        uint256 nonce
+    );
+    event Asset_Removed(address indexed asset_source, uint256 nonce);
 
     /***************************FUNCTIONS*************************/
     /// @notice This function lists the given ERC20 token contract as valid for deposit to this bridge
@@ -23,7 +44,12 @@ abstract contract IERC20_Bridge_Logic {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit Asset_Listed if successful
-    function list_asset(address asset_source, bytes32 vega_asset_id, uint256 nonce, bytes memory signatures) public virtual;
+    function list_asset(
+        address asset_source,
+        bytes32 vega_asset_id,
+        uint256 nonce,
+        bytes memory signatures
+    ) public virtual;
 
     /// @notice This function removes from listing the given ERC20 token contract. This marks the token as valid for deposit to this bridge
     /// @param asset_source Contract address for given ERC20 token
@@ -31,7 +57,11 @@ abstract contract IERC20_Bridge_Logic {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit Asset_Removed if successful
-    function remove_asset(address asset_source, uint256 nonce, bytes memory signatures) public virtual;
+    function remove_asset(
+        address asset_source,
+        uint256 nonce,
+        bytes memory signatures
+    ) public virtual;
 
     /// @notice This function sets the minimum allowable deposit for the given ERC20 token
     /// @param asset_source Contract address for given ERC20 token
@@ -40,7 +70,12 @@ abstract contract IERC20_Bridge_Logic {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit Asset_Deposit_Minimum_Set if successful
-    function set_deposit_minimum(address asset_source, uint256 minimum_amount, uint256 nonce, bytes memory signatures) public virtual;
+    function set_deposit_minimum(
+        address asset_source,
+        uint256 minimum_amount,
+        uint256 nonce,
+        bytes memory signatures
+    ) public virtual;
 
     /// @notice This function sets the maximum allowable deposit for the given ERC20 token
     /// @param asset_source Contract address for given ERC20 token
@@ -49,7 +84,12 @@ abstract contract IERC20_Bridge_Logic {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit Asset_Deposit_Maximum_Set if successful
-    function set_deposit_maximum(address asset_source, uint256 maximum_amount, uint256 nonce, bytes memory signatures) public virtual;
+    function set_deposit_maximum(
+        address asset_source,
+        uint256 maximum_amount,
+        uint256 nonce,
+        bytes memory signatures
+    ) public virtual;
 
     /// @notice This function sets the maximum allowable deposit for the given ERC20 token
     /// @param asset_source Contract address for given ERC20 token
@@ -60,7 +100,14 @@ abstract contract IERC20_Bridge_Logic {
     /// @param signatures Vega-supplied signature bundle of a validator-signed order
     /// @notice See MultisigControl for more about signatures
     /// @dev MUST emit Asset_Withdrawn if successful
-    function withdraw_asset(address asset_source, uint256 amount, uint256 expiry, address target, uint256 nonce, bytes memory signatures) public virtual;
+    function withdraw_asset(
+        address asset_source,
+        uint256 amount,
+        uint256 expiry,
+        address target,
+        uint256 nonce,
+        bytes memory signatures
+    ) public virtual;
 
     /// @notice This function allows a user to deposit given ERC20 tokens into Vega
     /// @param asset_source Contract address for given ERC20 token
@@ -69,35 +116,62 @@ abstract contract IERC20_Bridge_Logic {
     /// @dev MUST emit Asset_Deposited if successful
     /// @dev ERC20 approve function should be run before running this
     /// @notice ERC20 approve function should be run before running this
-    function deposit_asset(address asset_source, uint256 amount, bytes32 vega_public_key) public virtual;
+    function deposit_asset(
+        address asset_source,
+        uint256 amount,
+        bytes32 vega_public_key
+    ) public virtual;
 
     /***************************VIEWS*****************************/
     /// @notice This view returns true if the given ERC20 token contract has been listed valid for deposit
     /// @param asset_source Contract address for given ERC20 token
     /// @return True if asset is listed
-    function is_asset_listed(address asset_source) public virtual view returns(bool);
+    function is_asset_listed(address asset_source)
+        public
+        view
+        virtual
+        returns (bool);
 
     /// @notice This view returns minimum valid deposit
     /// @param asset_source Contract address for given ERC20 token
     /// @return Minimum valid deposit of given ERC20 token
-    function get_deposit_minimum(address asset_source) public virtual view returns(uint256);
+    function get_deposit_minimum(address asset_source)
+        public
+        view
+        virtual
+        returns (uint256);
 
     /// @notice This view returns maximum valid deposit
     /// @param asset_source Contract address for given ERC20 token
     /// @return Maximum valid deposit of given ERC20 token
-    function get_deposit_maximum(address asset_source) public virtual view returns(uint256);
+    function get_deposit_maximum(address asset_source)
+        public
+        view
+        virtual
+        returns (uint256);
 
     /// @return current multisig_control_address
-    function get_multisig_control_address() public virtual view returns(address);
+    function get_multisig_control_address()
+        public
+        view
+        virtual
+        returns (address);
 
     /// @param asset_source Contract address for given ERC20 token
     /// @return The assigned Vega Asset Id for given ERC20 token
-    function get_vega_asset_id(address asset_source) public virtual view returns(bytes32);
+    function get_vega_asset_id(address asset_source)
+        public
+        view
+        virtual
+        returns (bytes32);
 
     /// @param vega_asset_id Vega-assigned asset ID for which you want the ERC20 token address
     /// @return The ERC20 token contract address for a given Vega Asset Id
-    function get_asset_source(bytes32 vega_asset_id) public virtual view returns(address);
-
+    function get_asset_source(bytes32 vega_asset_id)
+        public
+        view
+        virtual
+        returns (address);
 }
 
 /**

--- a/contracts/tests/IERC20_Bridge_Logic.sol
+++ b/contracts/tests/IERC20_Bridge_Logic.sol
@@ -7,33 +7,16 @@ pragma solidity 0.8.8;
 // @notice All funds deposited/withdrawn are to/from the ERC20_Asset_Pool
 abstract contract IERC20_Bridge_Logic {
     /***************************EVENTS****************************/
-    event Asset_Withdrawn(
-        address indexed user_address,
-        address indexed asset_source,
-        uint256 amount,
-        uint256 nonce
-    );
+    event Asset_Withdrawn(address indexed user_address, address indexed asset_source, uint256 amount, uint256 nonce);
     event Asset_Deposited(
         address indexed user_address,
         address indexed asset_source,
         uint256 amount,
         bytes32 vega_public_key
     );
-    event Asset_Deposit_Minimum_Set(
-        address indexed asset_source,
-        uint256 new_minimum,
-        uint256 nonce
-    );
-    event Asset_Deposit_Maximum_Set(
-        address indexed asset_source,
-        uint256 new_maximum,
-        uint256 nonce
-    );
-    event Asset_Listed(
-        address indexed asset_source,
-        bytes32 indexed vega_asset_id,
-        uint256 nonce
-    );
+    event Asset_Deposit_Minimum_Set(address indexed asset_source, uint256 new_minimum, uint256 nonce);
+    event Asset_Deposit_Maximum_Set(address indexed asset_source, uint256 new_maximum, uint256 nonce);
+    event Asset_Listed(address indexed asset_source, bytes32 indexed vega_asset_id, uint256 nonce);
     event Asset_Removed(address indexed asset_source, uint256 nonce);
 
     /***************************FUNCTIONS*************************/
@@ -126,52 +109,28 @@ abstract contract IERC20_Bridge_Logic {
     /// @notice This view returns true if the given ERC20 token contract has been listed valid for deposit
     /// @param asset_source Contract address for given ERC20 token
     /// @return True if asset is listed
-    function is_asset_listed(address asset_source)
-        public
-        view
-        virtual
-        returns (bool);
+    function is_asset_listed(address asset_source) public view virtual returns (bool);
 
     /// @notice This view returns minimum valid deposit
     /// @param asset_source Contract address for given ERC20 token
     /// @return Minimum valid deposit of given ERC20 token
-    function get_deposit_minimum(address asset_source)
-        public
-        view
-        virtual
-        returns (uint256);
+    function get_deposit_minimum(address asset_source) public view virtual returns (uint256);
 
     /// @notice This view returns maximum valid deposit
     /// @param asset_source Contract address for given ERC20 token
     /// @return Maximum valid deposit of given ERC20 token
-    function get_deposit_maximum(address asset_source)
-        public
-        view
-        virtual
-        returns (uint256);
+    function get_deposit_maximum(address asset_source) public view virtual returns (uint256);
 
     /// @return current multisig_control_address
-    function get_multisig_control_address()
-        public
-        view
-        virtual
-        returns (address);
+    function get_multisig_control_address() public view virtual returns (address);
 
     /// @param asset_source Contract address for given ERC20 token
     /// @return The assigned Vega Asset Id for given ERC20 token
-    function get_vega_asset_id(address asset_source)
-        public
-        view
-        virtual
-        returns (bytes32);
+    function get_vega_asset_id(address asset_source) public view virtual returns (bytes32);
 
     /// @param vega_asset_id Vega-assigned asset ID for which you want the ERC20 token address
     /// @return The ERC20 token contract address for a given Vega Asset Id
-    function get_asset_source(bytes32 vega_asset_id)
-        public
-        view
-        virtual
-        returns (address);
+    function get_asset_source(bytes32 vega_asset_id) public view virtual returns (address);
 }
 
 /**

--- a/contracts/tests/IStake.sol
+++ b/contracts/tests/IStake.sol
@@ -6,23 +6,37 @@ pragma solidity 0.8.8;
  * @dev Interface contains all of the events necessary for staking Vega token
  */
 interface IStake {
-  event Stake_Deposited(address indexed user, uint256 amount, bytes32 indexed vega_public_key);
-  event Stake_Removed(address indexed user, uint256 amount, bytes32 indexed vega_public_key);
-  event Stake_Transferred(address indexed from, uint256 amount, address indexed to, bytes32 indexed vega_public_key);
+    event Stake_Deposited(
+        address indexed user,
+        uint256 amount,
+        bytes32 indexed vega_public_key
+    );
+    event Stake_Removed(
+        address indexed user,
+        uint256 amount,
+        bytes32 indexed vega_public_key
+    );
+    event Stake_Transferred(
+        address indexed from,
+        uint256 amount,
+        address indexed to,
+        bytes32 indexed vega_public_key
+    );
 
-  /// @return the address of the token that is able to be staked
-  function staking_token() external view returns (address);
+    /// @return the address of the token that is able to be staked
+    function staking_token() external view returns (address);
 
-  /// @param target Target address to check
-  /// @param vega_public_key Target vega public key to check
-  /// @return the number of tokens staked for that address->vega_public_key pair
-  function stake_balance(address target, bytes32 vega_public_key) external view returns (uint256);
+    /// @param target Target address to check
+    /// @param vega_public_key Target vega public key to check
+    /// @return the number of tokens staked for that address->vega_public_key pair
+    function stake_balance(address target, bytes32 vega_public_key)
+        external
+        view
+        returns (uint256);
 
-
-  /// @return total tokens staked on contract
-  function total_staked() external view returns (uint256);
+    /// @return total tokens staked on contract
+    function total_staked() external view returns (uint256);
 }
-
 
 /**
 MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM

--- a/contracts/tests/IStake.sol
+++ b/contracts/tests/IStake.sol
@@ -6,22 +6,9 @@ pragma solidity 0.8.8;
  * @dev Interface contains all of the events necessary for staking Vega token
  */
 interface IStake {
-    event Stake_Deposited(
-        address indexed user,
-        uint256 amount,
-        bytes32 indexed vega_public_key
-    );
-    event Stake_Removed(
-        address indexed user,
-        uint256 amount,
-        bytes32 indexed vega_public_key
-    );
-    event Stake_Transferred(
-        address indexed from,
-        uint256 amount,
-        address indexed to,
-        bytes32 indexed vega_public_key
-    );
+    event Stake_Deposited(address indexed user, uint256 amount, bytes32 indexed vega_public_key);
+    event Stake_Removed(address indexed user, uint256 amount, bytes32 indexed vega_public_key);
+    event Stake_Transferred(address indexed from, uint256 amount, address indexed to, bytes32 indexed vega_public_key);
 
     /// @return the address of the token that is able to be staked
     function staking_token() external view returns (address);
@@ -29,10 +16,7 @@ interface IStake {
     /// @param target Target address to check
     /// @param vega_public_key Target vega public key to check
     /// @return the number of tokens staked for that address->vega_public_key pair
-    function stake_balance(address target, bytes32 vega_public_key)
-        external
-        view
-        returns (uint256);
+    function stake_balance(address target, bytes32 vega_public_key) external view returns (uint256);
 
     /// @return total tokens staked on contract
     function total_staked() external view returns (uint256);

--- a/contracts/tests/Migrations.sol
+++ b/contracts/tests/Migrations.sol
@@ -2,18 +2,18 @@
 pragma solidity 0.8.8;
 
 contract Migrations {
-  address public owner;
-  uint public last_completed_migration;
+    address public owner;
+    uint256 public last_completed_migration;
 
-  constructor() {
-    owner = msg.sender;
-  }
+    constructor() {
+        owner = msg.sender;
+    }
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
-  }
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
 
-  function setCompleted(uint completed) public restricted {
-    last_completed_migration = completed;
-  }
+    function setCompleted(uint256 completed) public restricted {
+        last_completed_migration = completed;
+    }
 }

--- a/contracts/tests/Ownable.sol
+++ b/contracts/tests/Ownable.sol
@@ -13,10 +13,7 @@ pragma solidity 0.8.8;
 contract Ownable {
     address private _owner;
 
-    event OwnershipTransferred(
-        address indexed previousOwner,
-        address indexed newOwner
-    );
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     /**
      * @dev Initializes the contract setting the deployer as the initial owner.
@@ -72,10 +69,7 @@ contract Ownable {
      * @dev Transfers ownership of the contract to a new account (`newOwner`).
      */
     function _transferOwnership(address newOwner) internal {
-        require(
-            newOwner != address(0),
-            "Ownable: new owner is the zero address"
-        );
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
         emit OwnershipTransferred(_owner, newOwner);
         _owner = newOwner;
     }

--- a/contracts/tests/Ownable.sol
+++ b/contracts/tests/Ownable.sol
@@ -13,12 +13,15 @@ pragma solidity 0.8.8;
 contract Ownable {
     address private _owner;
 
-    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event OwnershipTransferred(
+        address indexed previousOwner,
+        address indexed newOwner
+    );
 
     /**
      * @dev Initializes the contract setting the deployer as the initial owner.
      */
-    constructor () {
+    constructor() {
         _owner = msg.sender;
         emit OwnershipTransferred(address(0), _owner);
     }
@@ -69,7 +72,10 @@ contract Ownable {
      * @dev Transfers ownership of the contract to a new account (`newOwner`).
      */
     function _transferOwnership(address newOwner) internal {
-        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        require(
+            newOwner != address(0),
+            "Ownable: new owner is the zero address"
+        );
         emit OwnershipTransferred(_owner, newOwner);
         _owner = newOwner;
     }

--- a/contracts/tests/SafeMath.sol
+++ b/contracts/tests/SafeMath.sol
@@ -6,43 +6,42 @@ pragma solidity 0.8.8;
  * @dev Math operations with safety checks that throw on error
  */
 library SafeMath {
-
-  /**
-  * @dev Multiplies two numbers, throws on overflow.
-  */
-  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
-    if (a == 0) {
-      return 0;
+    /**
+     * @dev Multiplies two numbers, throws on overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        if (a == 0) {
+            return 0;
+        }
+        uint256 c = a * b;
+        assert(c / a == b);
+        return c;
     }
-    uint256 c = a * b;
-    assert(c / a == b);
-    return c;
-  }
 
-  /**
-  * @dev Integer division of two numbers, truncating the quotient.
-  */
-  function div(uint256 a, uint256 b) internal pure returns (uint256) {
-    // assert(b > 0); // Solidity automatically throws when dividing by 0
-    // uint256 c = a / b;
-    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
-    return a / b;
-  }
+    /**
+     * @dev Integer division of two numbers, truncating the quotient.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        // assert(b > 0); // Solidity automatically throws when dividing by 0
+        // uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+        return a / b;
+    }
 
-  /**
-  * @dev Subtracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
-  */
-  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-    assert(b <= a);
-    return a - b;
-  }
+    /**
+     * @dev Subtracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        assert(b <= a);
+        return a - b;
+    }
 
-  /**
-  * @dev Adds two numbers, throws on overflow.
-  */
-  function add(uint256 a, uint256 b) internal pure returns (uint256) {
-    uint256 c = a + b;
-    assert(c >= a);
-    return c;
-  }
+    /**
+     * @dev Adds two numbers, throws on overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        assert(c >= a);
+        return c;
+    }
 }

--- a/contracts/tests/Vega_Staking_Bridge.sol
+++ b/contracts/tests/Vega_Staking_Bridge.sol
@@ -23,13 +23,7 @@ contract Vega_Staking_Bridge is IStake {
     /// @dev Emits Stake_Deposited event
     /// @dev User MUST run "approve" on token prior to running Stake
     function stake(uint256 amount, bytes32 vega_public_key) public {
-        require(
-            IERC20(_staking_token).transferFrom(
-                msg.sender,
-                address(this),
-                amount
-            )
-        );
+        require(IERC20(_staking_token).transferFrom(msg.sender, address(this), amount));
         stakes[msg.sender][vega_public_key] += amount;
         emit Stake_Deposited(msg.sender, amount, vega_public_key);
     }
@@ -56,12 +50,7 @@ contract Vega_Staking_Bridge is IStake {
     ) public {
         stakes[msg.sender][vega_public_key] -= amount;
         stakes[new_address][vega_public_key] += amount;
-        emit Stake_Transferred(
-            msg.sender,
-            amount,
-            new_address,
-            vega_public_key
-        );
+        emit Stake_Transferred(msg.sender, amount, new_address, vega_public_key);
     }
 
     /// @dev This is IStake.staking_token
@@ -74,12 +63,7 @@ contract Vega_Staking_Bridge is IStake {
     /// @param target Target address to check
     /// @param vega_public_key Target vega public key to check
     /// @return the number of tokens staked for that address->vega_public_key pair
-    function stake_balance(address target, bytes32 vega_public_key)
-        external
-        view
-        override
-        returns (uint256)
-    {
+    function stake_balance(address target, bytes32 vega_public_key) external view override returns (uint256) {
         return stakes[target][vega_public_key];
     }
 

--- a/contracts/tests/Vega_Staking_Bridge.sol
+++ b/contracts/tests/Vega_Staking_Bridge.sol
@@ -1,4 +1,3 @@
-
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.8;
 
@@ -9,68 +8,87 @@ import "./IStake.sol";
 /// @author Vega Protocol
 /// @notice This contract manages the vesting of the Vega V2 ERC20 token
 contract Vega_Staking_Bridge is IStake {
-  address _staking_token;
+    address _staking_token;
 
-  constructor(address token) {
-    _staking_token = token;
-  }
+    constructor(address token) {
+        _staking_token = token;
+    }
 
-  /// @dev user => amount staked
-  mapping(address => mapping(bytes32 => uint256)) stakes;
+    /// @dev user => amount staked
+    mapping(address => mapping(bytes32 => uint256)) stakes;
 
-  /// @notice This stakes the given amount of tokens and credits them to the provided Vega public key
-  /// @param amount Token amount to stake
-  /// @param vega_public_key Target Vega public key to be credited with the stake
-  /// @dev Emits Stake_Deposited event
-  /// @dev User MUST run "approve" on token prior to running Stake
-  function stake(uint256 amount, bytes32 vega_public_key) public {
-    require(IERC20(_staking_token).transferFrom(msg.sender, address(this), amount));
-    stakes[msg.sender][vega_public_key] += amount;
-    emit Stake_Deposited(msg.sender, amount, vega_public_key);
-  }
+    /// @notice This stakes the given amount of tokens and credits them to the provided Vega public key
+    /// @param amount Token amount to stake
+    /// @param vega_public_key Target Vega public key to be credited with the stake
+    /// @dev Emits Stake_Deposited event
+    /// @dev User MUST run "approve" on token prior to running Stake
+    function stake(uint256 amount, bytes32 vega_public_key) public {
+        require(
+            IERC20(_staking_token).transferFrom(
+                msg.sender,
+                address(this),
+                amount
+            )
+        );
+        stakes[msg.sender][vega_public_key] += amount;
+        emit Stake_Deposited(msg.sender, amount, vega_public_key);
+    }
 
-  /// @notice This removes specified amount of stake of available to user
-  /// @dev Emits Stake_Removed event if successful
-  /// @param amount Amount of tokens to remove from staking
-  /// @param vega_public_key Target Vega public key from which to deduct stake
-  function remove_stake(uint256 amount, bytes32 vega_public_key) public {
-    stakes[msg.sender][vega_public_key] -= amount;
-    require(IERC20(_staking_token).transfer(msg.sender, amount));
-    emit Stake_Removed(msg.sender, amount, vega_public_key);
-  }
+    /// @notice This removes specified amount of stake of available to user
+    /// @dev Emits Stake_Removed event if successful
+    /// @param amount Amount of tokens to remove from staking
+    /// @param vega_public_key Target Vega public key from which to deduct stake
+    function remove_stake(uint256 amount, bytes32 vega_public_key) public {
+        stakes[msg.sender][vega_public_key] -= amount;
+        require(IERC20(_staking_token).transfer(msg.sender, amount));
+        emit Stake_Removed(msg.sender, amount, vega_public_key);
+    }
 
-  /// @notice This transfers all stake from the sender's address to the "new_address"
-  /// @dev Emits Stake_Transfered event if successful
-  /// @param amount Stake amount to transfer
-  /// @param new_address Target ETH address to recieve the stake
-  /// @param vega_public_key Target Vega public key to be credited with the transfer
-  function transfer_stake(uint256 amount, address new_address, bytes32 vega_public_key) public {
-    stakes[msg.sender][vega_public_key] -= amount;
-    stakes[new_address][vega_public_key] += amount;
-    emit Stake_Transferred(msg.sender, amount, new_address, vega_public_key);
-  }
+    /// @notice This transfers all stake from the sender's address to the "new_address"
+    /// @dev Emits Stake_Transfered event if successful
+    /// @param amount Stake amount to transfer
+    /// @param new_address Target ETH address to recieve the stake
+    /// @param vega_public_key Target Vega public key to be credited with the transfer
+    function transfer_stake(
+        uint256 amount,
+        address new_address,
+        bytes32 vega_public_key
+    ) public {
+        stakes[msg.sender][vega_public_key] -= amount;
+        stakes[new_address][vega_public_key] += amount;
+        emit Stake_Transferred(
+            msg.sender,
+            amount,
+            new_address,
+            vega_public_key
+        );
+    }
 
-  /// @dev This is IStake.staking_token
-  /// @return the address of the token that is able to be staked
-  function staking_token() external override view returns (address) {
-    return _staking_token;
-  }
+    /// @dev This is IStake.staking_token
+    /// @return the address of the token that is able to be staked
+    function staking_token() external view override returns (address) {
+        return _staking_token;
+    }
 
-  /// @dev This is IStake.stake_balance
-  /// @param target Target address to check
-  /// @param vega_public_key Target vega public key to check
-  /// @return the number of tokens staked for that address->vega_public_key pair
-  function stake_balance(address target, bytes32 vega_public_key) external override view returns (uint256) {
-    return  stakes[target][vega_public_key];
-  }
+    /// @dev This is IStake.stake_balance
+    /// @param target Target address to check
+    /// @param vega_public_key Target vega public key to check
+    /// @return the number of tokens staked for that address->vega_public_key pair
+    function stake_balance(address target, bytes32 vega_public_key)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return stakes[target][vega_public_key];
+    }
 
-  /// @dev This is IStake.total_staked
-  /// @return total tokens staked on contract
-  function total_staked() external override view returns (uint256) {
-    return IERC20(_staking_token).balanceOf(address(this));
-  }
+    /// @dev This is IStake.total_staked
+    /// @return total tokens staked on contract
+    function total_staked() external view override returns (uint256) {
+        return IERC20(_staking_token).balanceOf(address(this));
+    }
 }
-
 
 /**
 MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
         "web3": "^1.2.11"
       },
       "devDependencies": {
+        "prettier": "^2.6.2",
+        "prettier-plugin-solidity": "^1.0.0-beta.19",
         "solidity-coverage": "^0.7.17"
       }
     },
@@ -22136,29 +22138,32 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
-      "optional": true,
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "devOptional": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-plugin-solidity": {
-      "version": "1.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.18.tgz",
-      "integrity": "sha512-ezWdsG/jIeClmYBzg8V9Voy8jujt+VxWF8OS3Vld+C3c+3cPVib8D9l8ahTod7O5Df1anK9zo+WiiS5wb1mLmg==",
-      "optional": true,
+      "version": "1.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.19.tgz",
+      "integrity": "sha512-xxRQ5ZiiZyUoMFLE9h7HnUDXI/daf1tnmL1msEdcKmyh7ZGQ4YklkYLC71bfBpYU2WruTb5/SFLUaEb3RApg5g==",
+      "devOptional": true,
       "dependencies": {
-        "@solidity-parser/parser": "^0.13.2",
-        "emoji-regex": "^9.2.2",
+        "@solidity-parser/parser": "^0.14.0",
+        "emoji-regex": "^10.0.0",
         "escape-string-regexp": "^4.0.0",
         "semver": "^7.3.5",
         "solidity-comments-extractor": "^0.0.7",
-        "string-width": "^4.2.2"
+        "string-width": "^4.2.3"
       },
       "engines": {
         "node": ">=12"
@@ -22168,10 +22173,10 @@
       }
     },
     "node_modules/prettier-plugin-solidity/node_modules/@solidity-parser/parser": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.13.2.tgz",
-      "integrity": "sha512-RwHnpRnfrnD2MSPveYoPh8nhofEvX7fgjHk1Oq+NNvCcLx4r1js91CO9o+F/F3fBzOCyvm8kKRTriFICX/odWw==",
-      "optional": true,
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.1.tgz",
+      "integrity": "sha512-eLjj2L6AuQjBB6s/ibwCAc0DwrR5Ge+ys+wgWo+bviU7fV2nTMQhU63CGaDKXg9iTmMxwhkyoggdIR7ZGRfMgw==",
+      "devOptional": true,
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
       }
@@ -22180,22 +22185,22 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/prettier-plugin-solidity/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "optional": true
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
+      "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==",
+      "devOptional": true
     },
     "node_modules/prettier-plugin-solidity/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       },
@@ -22207,7 +22212,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -22216,7 +22221,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -22228,7 +22233,7 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -22243,7 +22248,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -22257,13 +22262,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/prettier-plugin-solidity/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -22275,7 +22280,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/printj": {
       "version": "1.1.2",
@@ -24626,7 +24631,7 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz",
       "integrity": "sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/solidity-coverage": {
       "version": "0.7.17",
@@ -47576,30 +47581,30 @@
       "optional": true
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
-      "optional": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "devOptional": true
     },
     "prettier-plugin-solidity": {
-      "version": "1.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.18.tgz",
-      "integrity": "sha512-ezWdsG/jIeClmYBzg8V9Voy8jujt+VxWF8OS3Vld+C3c+3cPVib8D9l8ahTod7O5Df1anK9zo+WiiS5wb1mLmg==",
-      "optional": true,
+      "version": "1.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.19.tgz",
+      "integrity": "sha512-xxRQ5ZiiZyUoMFLE9h7HnUDXI/daf1tnmL1msEdcKmyh7ZGQ4YklkYLC71bfBpYU2WruTb5/SFLUaEb3RApg5g==",
+      "devOptional": true,
       "requires": {
-        "@solidity-parser/parser": "^0.13.2",
-        "emoji-regex": "^9.2.2",
+        "@solidity-parser/parser": "^0.14.0",
+        "emoji-regex": "^10.0.0",
         "escape-string-regexp": "^4.0.0",
         "semver": "^7.3.5",
         "solidity-comments-extractor": "^0.0.7",
-        "string-width": "^4.2.2"
+        "string-width": "^4.2.3"
       },
       "dependencies": {
         "@solidity-parser/parser": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.13.2.tgz",
-          "integrity": "sha512-RwHnpRnfrnD2MSPveYoPh8nhofEvX7fgjHk1Oq+NNvCcLx4r1js91CO9o+F/F3fBzOCyvm8kKRTriFICX/odWw==",
-          "optional": true,
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.1.tgz",
+          "integrity": "sha512-eLjj2L6AuQjBB6s/ibwCAc0DwrR5Ge+ys+wgWo+bviU7fV2nTMQhU63CGaDKXg9iTmMxwhkyoggdIR7ZGRfMgw==",
+          "devOptional": true,
           "requires": {
             "antlr4ts": "^0.5.0-alpha.4"
           }
@@ -47608,31 +47613,31 @@
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
           "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "optional": true
+          "devOptional": true
         },
         "emoji-regex": {
-          "version": "9.2.2",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-          "optional": true
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
+          "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==",
+          "devOptional": true
         },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "optional": true
+          "devOptional": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "optional": true
+          "devOptional": true
         },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "optional": true,
+          "devOptional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -47641,7 +47646,7 @@
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "optional": true,
+          "devOptional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -47650,7 +47655,7 @@
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
           "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "optional": true,
+          "devOptional": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -47661,7 +47666,7 @@
               "version": "8.0.0",
               "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
               "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-              "optional": true
+              "devOptional": true
             }
           }
         },
@@ -47669,7 +47674,7 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
           "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "optional": true,
+          "devOptional": true,
           "requires": {
             "ansi-regex": "^5.0.1"
           }
@@ -47678,7 +47683,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "optional": true
+          "devOptional": true
         }
       }
     },
@@ -49562,7 +49567,7 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz",
       "integrity": "sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==",
-      "optional": true
+      "devOptional": true
     },
     "solidity-coverage": {
       "version": "0.7.17",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "directories": {
     "test": "test"
   },
-  "scripts":{
+  "scripts": {
     "ganache": "ganache-cli -a=20 -m=\"$(echo $(cat .secret))\""
   },
   "dependencies": {
@@ -32,6 +32,8 @@
     "web3": "^1.2.11"
   },
   "devDependencies": {
+    "prettier": "^2.6.2",
+    "prettier-plugin-solidity": "^1.0.0-beta.19",
     "solidity-coverage": "^0.7.17"
   },
   "repository": {


### PR DESCRIPTION
Just found that most projects are using prettier, and I think it would be a good idea to follow the community guidelines in term of code style. I believe it makes it easier for anyone to read the code / contribute to the project, without being affraid of not following standards.

If we are happy with this, I suggest we also add a github action to run prettier on all PRs